### PR TITLE
Noto fonts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,15 @@ RUN apt-get update \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt-get update \
     && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 \
-      --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /src/*.deb
+      --no-install-recommends
+# Install missing fonts (e.g. trebuchet)
+RUN apt-get install fontconfig \
+    && wget http://ftp.br.debian.org/debian/pool/contrib/m/msttcorefonts/ttf-mscorefonts-installer_3.6_all.deb \
+    && apt --fix-broken install -y ./ttf-mscorefonts-installer_3.6_all.deb \
+    && rm ttf-mscorefonts-installer_3.6_all.deb \
+    && fc-cache -f -v
+# Secure everything
+RUN rm -rf /var/lib/apt/lists/* && rm -rf /src/*.deb
 
 # If running Docker >= 1.13.0 use docker run's --init arg to reap zombie processes, otherwise
 # uncomment the following lines to have `dumb-init` as PID 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:15
+FROM node:16-buster
 LABEL maintainer="Jihchi Lee <achi@987.tw>"
 
 RUN mkdir -p /usr/src/app
@@ -13,19 +13,20 @@ RUN apt-get update && apt-get -yq upgrade && apt-get install \
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
 # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
 # installs, work.
-RUN apt-get update \
+RUN sed -i -e's/ main/ main contrib non-free/g' /etc/apt/sources.list \ 
+    && apt-get update \
     && apt-get install -y wget gnupg \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt-get update \
     && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 \
+        fonts-noto \
+        fonts-noto-color-emoji \
+        ttf-mscorefonts-installer \
+        fontconfig \
       --no-install-recommends
-# Install missing fonts (e.g. trebuchet)
-RUN apt-get install fontconfig \
-    && wget http://ftp.br.debian.org/debian/pool/contrib/m/msttcorefonts/ttf-mscorefonts-installer_3.6_all.deb \
-    && apt --fix-broken install -y ./ttf-mscorefonts-installer_3.6_all.deb \
-    && rm ttf-mscorefonts-installer_3.6_all.deb \
-    && fc-cache -f -v
+# rebuild font cache
+RUN fc-cache -f -v
 # Secure everything
 RUN rm -rf /var/lib/apt/lists/* && rm -rf /src/*.deb
 


### PR DESCRIPTION
This is a follow-up to #29 that adds in a few more fonts and moves the version of debian to buster so that the emoji fonts are available.