### PR TITLE
feat: increase resolution on images

### DIFF
--- a/src/static/mermaid.html
+++ b/src/static/mermaid.html
@@ -11,6 +11,12 @@
       rel="stylesheet"
       href="../../node_modules/@fortawesome/fontawesome-free/css/v4-shims.min.css"
     />
+    <style>
+      svg {
+        max-width: none !important;
+        height: 100% !important;
+      }
+    </style>
   </head>
   <body>
     <div id="container"></div>


### PR DESCRIPTION
Previously, even though the viewport size was set to pretty high, the image output was blurry because the SVG wasn't enlarging to fit into the whole viewport. This PR removes mermaid's `max-width` and sets the height to `100%` to make sure the image resolution is much higher.