### PR TITLE
Allow setting diagram size, theme and add PDF output support. Fix som…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,4 +4,4 @@
 !package.json
 !pnpm-lock.yaml
 !src/*
-|LICENCE
+!LICENCE

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ RUN usermod -a -G audio,video node \
   && chown -R node:node /home/node /usr/src/app/
 
 USER node
+RUN corepack pack
 CMD ["pnpm", "start"]
 
 EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ wget https://raw.githubusercontent.com/jfrazelle/dotfiles/master/etc/docker/secc
 docker run --security-opt seccomp=$(pwd)/chrome.json ghcr.io/jihchi/mermaid.ink
 ```
 
+### Environment variables
+
+- **MAX_WIDTH**, **MAX_HEIGHT**: These determine the maximum scaled diagram width and height that can be requested (defaults to 10,000)
+
+- **FONT_AWESOME_CSS_URL**: Sets a custom URL for the injected font-awesome CSS in the SVG. The string 'FA_VERSION' will be replaced with the version of font-awesome in use by the application e.g., https://cdnjs.cloudflare.com/ajax/libs/font-awesome/FA_VERSION/css/all.min.css. Leave unset for default.
+
 ## Troubleshooting
 
 ### I'm getting back `HTTP 431 Request Header Fields Too Large` error

--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@ docker run --security-opt seccomp=$(pwd)/chrome.json ghcr.io/jihchi/mermaid.ink
 
 ### Environment variables
 
-- **MAX_WIDTH**, **MAX_HEIGHT**: These determine the maximum scaled diagram width and height that can be requested (defaults to 10,000)
-
-- **FONT_AWESOME_CSS_URL**: Sets a custom URL for the injected font-awesome CSS in the SVG. The string 'FA_VERSION' will be replaced with the version of font-awesome in use by the application e.g., https://cdnjs.cloudflare.com/ajax/libs/font-awesome/FA_VERSION/css/all.min.css. Leave unset for default.
+| variable name | default value | description |
+| -- | -- | -- |
+| `MAX_WIDTH` | `10000` | Determine the maximum scaled diagram width that can be requested |
+| `MAX_HEIGHT` | `10000` | Determine the maximum scaled diagram height that can be requested |
+| `FONT_AWESOME_CSS_URL` | `<unset>` | Sets a custom URL for the injected font-awesome CSS in the SVG. <br><br> The string `FA_VERSION` will be replaced with the version of font-awesome in use by the application e.g., `https://cdnjs.cloudflare.com/ajax/libs/font-awesome/FA_VERSION/css/all.min.css`. |
 
 ## Troubleshooting
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "@happy-dom/jest-environment": "^14.3.6",
     "@testing-library/jest-dom": "^6.0.0",
     "jest": "^29.6.2",
+    "pdf-lib": "^1.17.1",
     "prettier": "^3.0.1",
+    "sharp": "^0.33.3",
     "supertest": "^6.3.3"
   },
   "packageManager": "pnpm@8.15.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,9 +46,15 @@ devDependencies:
   jest:
     specifier: ^29.6.2
     version: 29.7.0
+  pdf-lib:
+    specifier: ^1.17.1
+    version: 1.17.1
   prettier:
     specifier: ^3.0.1
     version: 3.2.5
+  sharp:
+    specifier: ^0.33.3
+    version: 0.33.3
   supertest:
     specifier: ^6.3.3
     version: 6.3.4
@@ -404,6 +410,14 @@ packages:
     resolution: {integrity: sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==}
     dev: false
 
+  /@emnapi/runtime@1.1.1:
+    resolution: {integrity: sha512-3bfqkzuR1KLx57nZfjr2NLnFOobvyS0aTszaEGCGqmYMVDRaGvgIZbjGSV/MHSSmLgQ/b9JFHQ5xm5WRZYd+XQ==}
+    requiresBuild: true
+    dependencies:
+      tslib: 2.6.1
+    dev: true
+    optional: true
+
   /@fortawesome/fontawesome-free@6.5.2:
     resolution: {integrity: sha512-hRILoInAx8GNT5IMkrtIt9blOdrqHOnPBH+k70aWUAqPZPgopb9G5EQJFpaBx/S8zp2fC+mPW349Bziuk1o28Q==}
     engines: {node: '>=6'}
@@ -421,6 +435,194 @@ packages:
       jest-mock: 29.7.0
       jest-util: 29.7.0
     dev: true
+
+  /@img/sharp-darwin-arm64@0.33.3:
+    resolution: {integrity: sha512-FaNiGX1MrOuJ3hxuNzWgsT/mg5OHG/Izh59WW2mk1UwYHUwtfbhk5QNKYZgxf0pLOhx9ctGiGa2OykD71vOnSw==}
+    engines: {glibc: '>=2.26', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.0.2
+    dev: true
+    optional: true
+
+  /@img/sharp-darwin-x64@0.33.3:
+    resolution: {integrity: sha512-2QeSl7QDK9ru//YBT4sQkoq7L0EAJZA3rtV+v9p8xTKl4U1bUqTIaCnoC7Ctx2kCjQgwFXDasOtPTCT8eCTXvw==}
+    engines: {glibc: '>=2.26', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.0.2
+    dev: true
+    optional: true
+
+  /@img/sharp-libvips-darwin-arm64@1.0.2:
+    resolution: {integrity: sha512-tcK/41Rq8IKlSaKRCCAuuY3lDJjQnYIW1UXU1kxcEKrfL8WR7N6+rzNoOxoQRJWTAECuKwgAHnPvqXGN8XfkHA==}
+    engines: {macos: '>=11', npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@img/sharp-libvips-darwin-x64@1.0.2:
+    resolution: {integrity: sha512-Ofw+7oaWa0HiiMiKWqqaZbaYV3/UGL2wAPeLuJTx+9cXpCRdvQhCLG0IH8YGwM0yGWGLpsF4Su9vM1o6aer+Fw==}
+    engines: {macos: '>=10.13', npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@img/sharp-libvips-linux-arm64@1.0.2:
+    resolution: {integrity: sha512-x7kCt3N00ofFmmkkdshwj3vGPCnmiDh7Gwnd4nUwZln2YjqPxV1NlTyZOvoDWdKQVDL911487HOueBvrpflagw==}
+    engines: {glibc: '>=2.26', npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@img/sharp-libvips-linux-arm@1.0.2:
+    resolution: {integrity: sha512-iLWCvrKgeFoglQxdEwzu1eQV04o8YeYGFXtfWU26Zr2wWT3q3MTzC+QTCO3ZQfWd3doKHT4Pm2kRmLbupT+sZw==}
+    engines: {glibc: '>=2.28', npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@img/sharp-libvips-linux-s390x@1.0.2:
+    resolution: {integrity: sha512-cmhQ1J4qVhfmS6szYW7RT+gLJq9dH2i4maq+qyXayUSn9/3iY2ZeWpbAgSpSVbV2E1JUL2Gg7pwnYQ1h8rQIog==}
+    engines: {glibc: '>=2.28', npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@img/sharp-libvips-linux-x64@1.0.2:
+    resolution: {integrity: sha512-E441q4Qdb+7yuyiADVi5J+44x8ctlrqn8XgkDTwr4qPJzWkaHwD489iZ4nGDgcuya4iMN3ULV6NwbhRZJ9Z7SQ==}
+    engines: {glibc: '>=2.26', npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@img/sharp-libvips-linuxmusl-arm64@1.0.2:
+    resolution: {integrity: sha512-3CAkndNpYUrlDqkCM5qhksfE+qSIREVpyoeHIU6jd48SJZViAmznoQQLAv4hVXF7xyUB9zf+G++e2v1ABjCbEQ==}
+    engines: {musl: '>=1.2.2', npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@img/sharp-libvips-linuxmusl-x64@1.0.2:
+    resolution: {integrity: sha512-VI94Q6khIHqHWNOh6LLdm9s2Ry4zdjWJwH56WoiJU7NTeDwyApdZZ8c+SADC8OH98KWNQXnE01UdJ9CSfZvwZw==}
+    engines: {musl: '>=1.2.2', npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@img/sharp-linux-arm64@0.33.3:
+    resolution: {integrity: sha512-Zf+sF1jHZJKA6Gor9hoYG2ljr4wo9cY4twaxgFDvlG0Xz9V7sinsPp8pFd1XtlhTzYo0IhDbl3rK7P6MzHpnYA==}
+    engines: {glibc: '>=2.26', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.0.2
+    dev: true
+    optional: true
+
+  /@img/sharp-linux-arm@0.33.3:
+    resolution: {integrity: sha512-Q7Ee3fFSC9P7vUSqVEF0zccJsZ8GiiCJYGWDdhEjdlOeS9/jdkyJ6sUSPj+bL8VuOYFSbofrW0t/86ceVhx32w==}
+    engines: {glibc: '>=2.28', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.0.2
+    dev: true
+    optional: true
+
+  /@img/sharp-linux-s390x@0.33.3:
+    resolution: {integrity: sha512-vFk441DKRFepjhTEH20oBlFrHcLjPfI8B0pMIxGm3+yilKyYeHEVvrZhYFdqIseSclIqbQ3SnZMwEMWonY5XFA==}
+    engines: {glibc: '>=2.28', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.0.2
+    dev: true
+    optional: true
+
+  /@img/sharp-linux-x64@0.33.3:
+    resolution: {integrity: sha512-Q4I++herIJxJi+qmbySd072oDPRkCg/SClLEIDh5IL9h1zjhqjv82H0Seupd+q2m0yOfD+/fJnjSoDFtKiHu2g==}
+    engines: {glibc: '>=2.26', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.0.2
+    dev: true
+    optional: true
+
+  /@img/sharp-linuxmusl-arm64@0.33.3:
+    resolution: {integrity: sha512-qnDccehRDXadhM9PM5hLvcPRYqyFCBN31kq+ErBSZtZlsAc1U4Z85xf/RXv1qolkdu+ibw64fUDaRdktxTNP9A==}
+    engines: {musl: '>=1.2.2', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.2
+    dev: true
+    optional: true
+
+  /@img/sharp-linuxmusl-x64@0.33.3:
+    resolution: {integrity: sha512-Jhchim8kHWIU/GZ+9poHMWRcefeaxFIs9EBqf9KtcC14Ojk6qua7ghKiPs0sbeLbLj/2IGBtDcxHyjCdYWkk2w==}
+    engines: {musl: '>=1.2.2', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.2
+    dev: true
+    optional: true
+
+  /@img/sharp-wasm32@0.33.3:
+    resolution: {integrity: sha512-68zivsdJ0koE96stdUfM+gmyaK/NcoSZK5dV5CAjES0FUXS9lchYt8LAB5rTbM7nlWtxaU/2GON0HVN6/ZYJAQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
+    cpu: [wasm32]
+    requiresBuild: true
+    dependencies:
+      '@emnapi/runtime': 1.1.1
+    dev: true
+    optional: true
+
+  /@img/sharp-win32-ia32@0.33.3:
+    resolution: {integrity: sha512-CyimAduT2whQD8ER4Ux7exKrtfoaUiVr7HG0zZvO0XTFn2idUWljjxv58GxNTkFb8/J9Ub9AqITGkJD6ZginxQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@img/sharp-win32-x64@0.33.3:
+    resolution: {integrity: sha512-viT4fUIDKnli3IfOephGnolMzhz5VaTvDRkYqtZxOMIoMQ4MrAziO7pT1nVnOt2FAm7qW5aa+CCc13aEY6Le0g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /@istanbuljs/load-nyc-config@1.1.0:
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
@@ -688,6 +890,18 @@ packages:
     dependencies:
       vary: 1.1.2
     dev: false
+
+  /@pdf-lib/standard-fonts@1.0.0:
+    resolution: {integrity: sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==}
+    dependencies:
+      pako: 1.0.11
+    dev: true
+
+  /@pdf-lib/upng@1.0.1:
+    resolution: {integrity: sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==}
+    dependencies:
+      pako: 1.0.11
+    dev: true
 
   /@puppeteer/browsers@2.2.1:
     resolution: {integrity: sha512-QSXujx4d4ogDamQA8ckkkRieFzDgZEuZuGiey9G7CuDcbnX4iINKWxTPC5Br2AEzY9ICAvcndqgAUFMMKnS/Tw==}
@@ -1237,6 +1451,21 @@ packages:
   /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  /color-string@1.9.1:
+    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
+    dependencies:
+      color-name: 1.1.4
+      simple-swizzle: 0.2.2
+    dev: true
+
+  /color@4.2.3:
+    resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
+    engines: {node: '>=12.5.0'}
+    dependencies:
+      color-convert: 2.0.1
+      color-string: 1.9.1
+    dev: true
+
   /combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
@@ -1729,6 +1958,11 @@ packages:
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
     dev: false
 
+  /detect-libc@2.0.3:
+    resolution: {integrity: sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==}
+    engines: {node: '>=8'}
+    dev: true
+
   /detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
@@ -2216,6 +2450,10 @@ packages:
 
   /is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  /is-arrayish@0.3.2:
+    resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
+    dev: true
 
   /is-core-module@2.13.0:
     resolution: {integrity: sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==}
@@ -3310,6 +3548,10 @@ packages:
       netmask: 2.0.2
     dev: false
 
+  /pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+    dev: true
+
   /pako@2.1.0:
     resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
     dev: false
@@ -3357,6 +3599,15 @@ packages:
   /path-to-regexp@6.2.2:
     resolution: {integrity: sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==}
     dev: false
+
+  /pdf-lib@1.17.1:
+    resolution: {integrity: sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==}
+    dependencies:
+      '@pdf-lib/standard-fonts': 1.0.0
+      '@pdf-lib/upng': 1.0.1
+      pako: 1.0.11
+      tslib: 1.14.1
+    dev: true
 
   /pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
@@ -3576,6 +3827,36 @@ packages:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
     dev: false
 
+  /sharp@0.33.3:
+    resolution: {integrity: sha512-vHUeXJU1UvlO/BNwTpT0x/r53WkLUVxrmb5JTgW92fdFCFk0ispLMAeu/jPO2vjkXM1fYUi3K7/qcLF47pwM1A==}
+    engines: {libvips: '>=8.15.2', node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    requiresBuild: true
+    dependencies:
+      color: 4.2.3
+      detect-libc: 2.0.3
+      semver: 7.6.0
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.33.3
+      '@img/sharp-darwin-x64': 0.33.3
+      '@img/sharp-libvips-darwin-arm64': 1.0.2
+      '@img/sharp-libvips-darwin-x64': 1.0.2
+      '@img/sharp-libvips-linux-arm': 1.0.2
+      '@img/sharp-libvips-linux-arm64': 1.0.2
+      '@img/sharp-libvips-linux-s390x': 1.0.2
+      '@img/sharp-libvips-linux-x64': 1.0.2
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.2
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.2
+      '@img/sharp-linux-arm': 0.33.3
+      '@img/sharp-linux-arm64': 0.33.3
+      '@img/sharp-linux-s390x': 0.33.3
+      '@img/sharp-linux-x64': 0.33.3
+      '@img/sharp-linuxmusl-arm64': 0.33.3
+      '@img/sharp-linuxmusl-x64': 0.33.3
+      '@img/sharp-wasm32': 0.33.3
+      '@img/sharp-win32-ia32': 0.33.3
+      '@img/sharp-win32-x64': 0.33.3
+    dev: true
+
   /shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -3598,6 +3879,12 @@ packages:
 
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+    dev: true
+
+  /simple-swizzle@0.2.2:
+    resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
+    dependencies:
+      is-arrayish: 0.3.2
     dev: true
 
   /sisteransi@1.0.5:
@@ -3825,9 +4112,12 @@ packages:
     engines: {node: '>=6.10'}
     dev: false
 
+  /tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+    dev: true
+
   /tslib@2.6.1:
     resolution: {integrity: sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==}
-    dev: false
 
   /tsscmp@1.0.6:
     resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}

--- a/src/app.js
+++ b/src/app.js
@@ -3,11 +3,20 @@ const cors = require('@koa/cors');
 const createDebug = require('debug');
 const route = require('koa-route');
 const puppeteer = require('puppeteer');
+
 const views = require('./views');
 
 const debug = createDebug('app:main');
 const pptr = createDebug('app:pptr');
 const app = new Koa();
+
+// Set global config
+app.use(async (ctx, next) => {
+  ctx.state.customFontAwesomeCssUrl = process.env.FONT_AWESOME_CSS_URL;
+  ctx.state.maxWidth = process.env.MAX_WIDTH ? process.env.MAX_WIDTH : 10000;
+  ctx.state.maxHeight = process.env.MAX_HEIGHT ? process.env.MAX_HEIGHT : 10000;
+  await next();
+});
 
 app.use(
   cors({
@@ -21,6 +30,7 @@ app.use(route.get('/', views.home));
 app.use(route.get('/services/oembed', views.servicesOembed));
 app.use(route.get('/img/:encodedCode', views.img));
 app.use(route.get('/svg/:encodedCode', views.svg));
+app.use(route.get('/pdf/:encodedCode', views.pdf));
 
 async function setup() {
   if (app.context.shutdown) {
@@ -32,7 +42,7 @@ async function setup() {
 
   app.context.browser = await puppeteer.launch({
     executablePath: process.env.PUPPETEER_SKIP_CHROMIUM_DOWNLOAD
-      ? 'google-chrome-stable'
+      ? '/usr/bin/google-chrome-stable'
       : undefined,
     headless: pptr.enabled ? false : 'new',
     devtools: pptr.enabled,

--- a/src/node_modules/getOptionsFromCode.js
+++ b/src/node_modules/getOptionsFromCode.js
@@ -1,11 +1,23 @@
-// copied from https://github.com/mermaidjs/mermaid-live-editor/blob/master/src/lib/util/serde.ts
+// copied from https://github.com/mermaid-js/mermaid-live-editor/blob/develop/src/lib/util/serde.ts
 const { inflate } = require('pako');
 const { toUint8Array, fromBase64 } = require('js-base64');
+
+class UnknownSerdeError extends Error {
+  constructor(message) {
+    super(message);
+  }
+}
 
 const deserializeState = (state) => {
   let type, serialized;
   if (state.includes(':')) {
-    [type, serialized] = state.split(':');
+    let tempType;
+    [tempType, serialized] = state.split(':');
+    if (tempType in deserializers) {
+      type = tempType;
+    } else {
+      throw new UnknownSerdeError(`Unknown serde type: ${tempType}`);
+    }
   } else {
     type = 'base64';
     serialized = state;
@@ -24,23 +36,31 @@ const deserializers = {
   },
 };
 
-module.exports = (base64) => {
-  const theme = 'default';
+module.exports = (serializedState) => {
   try {
-    return deserializeState(base64);
+    return deserializeState(serializedState);
   } catch (error) {
+    if (error instanceof UnknownSerdeError) {
+      // Re-throw serde error
+      throw error;
+    }
     // continue previous method.
   }
-  const str = Buffer.from(base64, 'base64').toString('utf8');
+
+  const str = Buffer.from(serializedState, 'base64').toString('utf8');
+  const defaultState = {
+    code: str,
+    mermaid: JSON.stringify({ theme: 'default' }),
+  };
   let state;
   try {
     state = JSON.parse(str);
     if (state.code === undefined) {
       // not valid json
-      state = { code: str, mermaid: { theme } };
+      state = defaultState;
     }
   } catch (e) {
-    state = { code: str, mermaid: { theme } };
+    state = defaultState;
   }
   return state;
 };

--- a/src/node_modules/renderImgOrSvg.js
+++ b/src/node_modules/renderImgOrSvg.js
@@ -14,23 +14,90 @@ function bgColorFromContext(ctx) {
   }
 }
 
+function sizeFromContext(ctx) {
+  let width = null;
+  let height = null;
+
+  if (ctx.query.width) {
+    const parsedWidth = parseInt(ctx.query.width);
+    if (!parsedWidth) {
+      ctx.throw(400, 'invalid width value');
+    }
+    width = parsedWidth;
+  }
+
+  if (ctx.query.height) {
+    const parsedHeight = parseInt(ctx.query.height);
+    if (!parsedHeight) {
+      ctx.throw(400, 'invalid height value');
+    }
+    height = parsedHeight;
+  }
+
+  let scale = 1;
+  if (ctx.query.scale) {
+    if (!width && !height) {
+      ctx.throw(
+        400,
+        'scale can only be set when either width or height is set'
+      );
+    }
+    const parsedScale = parseFloat(ctx.query.scale);
+    if (!parsedScale || parsedScale < 1 || parsedScale > 3) {
+      ctx.throw(400, 'invalid scale value - must be a number between 1 and 3');
+    }
+    scale = parsedScale;
+  }
+
+  if (width) {
+    width *= scale;
+
+    if (width <= 0 || (ctx.state.maxWidth && width > ctx.state.maxWidth)) {
+      ctx.throw(400, `the scaled width must be between 0 and ${ctx.maxWidth}`);
+    }
+  }
+
+  if (height) {
+    height *= scale;
+
+    if (height <= 0 || (ctx.state.maxHeight && height > ctx.state.maxHeight)) {
+      ctx.throw(
+        400,
+        `the scaled height must be between 0 and ${ctx.maxHeight}`
+      );
+    }
+  }
+
+  return { width, height };
+}
+
+function themeFromContext(ctx) {
+  return ['default', 'neutral', 'dark', 'forest'].includes(
+    ctx.query.theme?.toLowerCase()
+  )
+    ? ctx.query.theme?.toLowerCase()
+    : null;
+}
+
 module.exports = (render) => async (ctx, encodedCode, _next) => {
   debug(`start to render, code: ${encodedCode}`);
 
-  let page, bgColor;
+  let page;
   try {
     page = await openMermaidPage(ctx);
-    bgColor = bgColorFromContext(ctx);
+    const bgColor = bgColorFromContext(ctx);
+    const size = sizeFromContext(ctx);
+    const theme = themeFromContext(ctx);
     debug('loaded local mermaid page');
 
     try {
-      await renderSVG({ page, encodedCode, bgColor });
+      await renderSVG({ page, encodedCode, bgColor, size, theme });
       debug('rendered SVG in DOM');
     } catch (e) {
       debug('mermaid failed to render SVG: %o', e);
       ctx.throw(400, 'invalid encoded code');
     }
-    await render(ctx, page);
+    await render(ctx, page, size);
   } catch (e) {
     // here don't throw 500 if exception has already been thrown inside try-catch
     if (!ctx.headerSent) {

--- a/src/node_modules/renderSVG.js
+++ b/src/node_modules/renderSVG.js
@@ -1,17 +1,17 @@
 const getOptionsFromCode = require('./getOptionsFromCode');
 
-module.exports = async ({ page, encodedCode, bgColor }) => {
+module.exports = async ({ page, encodedCode, bgColor, size, theme }) => {
   const { code, mermaid: config } = getOptionsFromCode(encodedCode);
-
-  await page.evaluate((def, cfg) => window.App.render(def, cfg), code, config);
-
-  if (bgColor) {
-    await page.$eval(
-      '#container > svg',
-      (e, bg) => (e.style.backgroundColor = bg),
-      bgColor
-    );
+  const configObj = typeof config === 'string' ? JSON.parse(config) : config;
+  if (theme) {
+    configObj.theme = theme;
   }
 
-  return;
+  await page.evaluate(
+    (def, cfg, bgColor, size) => window.App.render(def, cfg, bgColor, size),
+    code,
+    configObj,
+    bgColor,
+    size
+  );
 };

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -21,6 +21,11 @@
       rel="stylesheet"
       href="https://unpkg.com/spectre.css/dist/spectre.min.css"
     />
+    <style>
+      .column {
+        padding: 0.4rem;
+      }
+    </style>
   </head>
   <body>
     <div class="container grid-lg">
@@ -89,16 +94,59 @@
             </li>
             <li>
               Done, you could use the URL as a regular image URL:
-              <p>
-                <img
-                  class="img-responsive"
-                  src="/img/pako:eNpNkM9qwzAMh19F6NRB8wI5DNak7aWwwXqLexCxUpvNf3AURkny7rNbynaTPn0_ITRjHzRjjddE0cC5VR7grWtMsqM4Gi9QVa_LkQVc8HxbYLc5BhhNiNH660uxd0WBZj4ViUGM9V9rGTT37LvnBdruRFFCvPzx809YYN_ZD5MX_-cmcU4cuoHqgaqeEjSUsqBECW7RcXJkdT55LiGFYtixwjqXmgeavkWh8mtWp6hJeK-thIS1pIm3SJOEz5vvn_3DaS3lB7gHXH8BFrFcZw"
-                  alt="A mermaid.ink chart example"
-                />
-              </p>
+              <div class="container">
+                <div class="columns">
+                  <div class="column col-5 col-md-12">
+                    <img
+                      class="img-responsive"
+                      src="/img/pako:eNpNkM9qwzAMh19F6NRB8wI5DNak7aWwwXqLexCxUpvNf3AURkny7rNbynaTPn0_ITRjHzRjjddE0cC5VR7grWtMsqM4Gi9QVa_LkQVc8HxbYLc5BhhNiNH660uxd0WBZj4ViUGM9V9rGTT37LvnBdruRFFCvPzx809YYN_ZD5MX_-cmcU4cuoHqgaqeEjSUsqBECW7RcXJkdT55LiGFYtixwjqXmgeavkWh8mtWp6hJeK-thIS1pIm3SJOEz5vvn_3DaS3lB7gHXH8BFrFcZw"
+                      alt="A mermaid.ink chart example"
+                    />
+                  </div>
+                </div>
+              </div>
             </li>
           </ol>
         </div>
+
+        <div class="column col-12">
+          <h3>Image type</h3>
+          <p>
+            You may select any of the following image types for the
+            <code>/img</code> endpoint by adding e.g. <code>?type=png</code>:
+          </p>
+          <ul>
+            <li><code>jpeg</code> (default)</li>
+            <li><code>png</code></li>
+            <li><code>webp</code></li>
+          </ul>
+          <p>Use <code>/svg</code> to get an SVG image.</p>
+        </div>
+
+        <div class="column col-12">
+          <h3>PDF output options</h3>
+          <p>
+            You can generate a PDF using <code>/pdf</code> endpoint. Add the
+            <code>fit</code> URL parameter to make the PDF size fit to the
+            diagram size. Add the <code>paper</code> URL parameter to set a
+            paper size format e.g. <code>paper=a3</code>. Default is
+            <code>a4</code>. The supported paper formats are listed
+            <a href="https://pptr.dev/api/puppeteer.paperformat">here</a>. This
+            has no effect if using <code>fit</code>. Add the
+            <code>landscape</code> URL parameter to make the PDF landscape. This
+            has no effect if using <code>fit</code>.
+          </p>
+          <p>Example:</p>
+          <pre
+            class="code"
+            data-lang="URL"
+          ><code><a href="/pdf/pako:eNpNkM9qwzAMh19F6NRB8wI5DNak7aWwwXqLexCxUpvNf3AURkny7rNbynaTPn0_ITRjHzRjjddE0cC5VR7grWtMsqM4Gi9QVa_LkQVc8HxbYLc5BhhNiNH660uxd0WBZj4ViUGM9V9rGTT37LvnBdruRFFCvPzx809YYN_ZD5MX_-cmcU4cuoHqgaqeEjSUsqBECW7RcXJkdT55LiGFYtixwjqXmgeavkWh8mtWp6hJeK-thIS1pIm3SJOEz5vvn_3DaS3lB7gHXH8BFrFcZw?fit">https://mermaid.ink/pdf/pako:eNpNkM9qwzAMh19F6NRB8wI5DNak7aWwwXqLexCxUpvNf3AURkny7rNbynaTPn0_ITRjHzRjjddE0cC5VR7grWtMsqM4Gi9QVa_LkQVc8HxbYLc5BhhNiNH660uxd0WBZj4ViUGM9V9rGTT37LvnBdruRFFCvPzx809YYN_ZD5MX_-cmcU4cuoHqgaqeEjSUsqBECW7RcXJkdT55LiGFYtixwjqXmgeavkWh8mtWp6hJeK-thIS1pIm3SJOEz5vvn_3DaS3lB7gHXH8BFrFcZw<mark>?fit</mark></a></code></pre>
+          <pre
+            class="code"
+            data-lang="URL"
+          ><code><a href="/pdf/pako:eNpNkM9qwzAMh19F6NRB8wI5DNak7aWwwXqLexCxUpvNf3AURkny7rNbynaTPn0_ITRjHzRjjddE0cC5VR7grWtMsqM4Gi9QVa_LkQVc8HxbYLc5BhhNiNH660uxd0WBZj4ViUGM9V9rGTT37LvnBdruRFFCvPzx809YYN_ZD5MX_-cmcU4cuoHqgaqeEjSUsqBECW7RcXJkdT55LiGFYtixwjqXmgeavkWh8mtWp6hJeK-thIS1pIm3SJOEz5vvn_3DaS3lB7gHXH8BFrFcZw?paper=a3&landscape&width=700">https://mermaid.ink/pdf/pako:eNpNkM9qwzAMh19F6NRB8wI5DNak7aWwwXqLexCxUpvNf3AURkny7rNbynaTPn0_ITRjHzRjjddE0cC5VR7grWtMsqM4Gi9QVa_LkQVc8HxbYLc5BhhNiNH660uxd0WBZj4ViUGM9V9rGTT37LvnBdruRFFCvPzx809YYN_ZD5MX_-cmcU4cuoHqgaqeEjSUsqBECW7RcXJkdT55LiGFYtixwjqXmgeavkWh8mtWp6hJeK-thIS1pIm3SJOEz5vvn_3DaS3lB7gHXH8BFrFcZw<mark>?paper=a3&landscape&width=700</mark></a></code></pre>
+        </div>
+
         <div class="column col-12">
           <h3>Background colors</h3>
           <p>Images are generated with a transparent background by default.</p>
@@ -136,6 +184,118 @@
                   class="img-responsive"
                   src="/svg/pako:eNpNkM9qwzAMh19F6NRB8wI5DNak7aWwwXqLexCxUpvNf3AURkny7rNbynaTPn0_ITRjHzRjjddE0cC5VR7grWtMsqM4Gi9QVa_LkQVc8HxbYLc5BhhNiNH660uxd0WBZj4ViUGM9V9rGTT37LvnBdruRFFCvPzx809YYN_ZD5MX_-cmcU4cuoHqgaqeEjSUsqBECW7RcXJkdT55LiGFYtixwjqXmgeavkWh8mtWp6hJeK-thIS1pIm3SJOEz5vvn_3DaS3lB7gHXH8BFrFcZw?bgColor=555555"
                   alt="mermaid chart example with background color"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="column col-12">
+          <h3>Themes</h3>
+          <p>
+            You can change the theme of the diagram without modifying the
+            diagram code. See the
+            <a href="https://mermaid.js.org/config/theming.html"
+              >mermaid theme docs</a
+            >
+            for details. Note that these are the built-in mermaid.js themes and
+            not the custom mermaid live editor themes.
+          </p>
+          <p>Current available theme options are:</p>
+          <ol>
+            <li>
+              <strong>default</strong> - This is the default theme for all
+              diagrams.
+            </li>
+            <li>
+              <strong>neutral</strong> - This theme is great for black and white
+              documents that will be printed.
+            </li>
+            <li>
+              <strong>dark</strong> - This theme goes well with dark-colored
+              elements or dark-mode.
+            </li>
+            <li>
+              <strong>forest</strong> - This theme contains shades of green.
+            </li>
+          </ol>
+          <p>Demo:</p>
+
+          <pre
+            class="code"
+            data-lang="URL"
+          ><code><a href="/img/pako:eNpNkM9qwzAMh19F6NRB8wI5DNak7aWwwXqLexCxUpvNf3AURkny7rNbynaTPn0_ITRjHzRjjddE0cC5VR7grWtMsqM4Gi9QVa_LkQVc8HxbYLc5BhhNiNH660uxd0WBZj4ViUGM9V9rGTT37LvnBdruRFFCvPzx809YYN_ZD5MX_-cmcU4cuoHqgaqeEjSUsqBECW7RcXJkdT55LiGFYtixwjqXmgeavkWh8mtWp6hJeK-thIS1pIm3SJOEz5vvn_3DaS3lB7gHXH8BFrFcZw?theme=dark">https://mermaid.ink/img/pako:eNpNkM9qwzAMh19F6NRB8wI5DNak7aWwwXqLexCxUpvNf3AURkny7rNbynaTPn0_ITRjHzRjjddE0cC5VR7grWtMsqM4Gi9QVa_LkQVc8HxbYLc5BhhNiNH660uxd0WBZj4ViUGM9V9rGTT37LvnBdruRFFCvPzx809YYN_ZD5MX_-cmcU4cuoHqgaqeEjSUsqBECW7RcXJkdT55LiGFYtixwjqXmgeavkWh8mtWp6hJeK-thIS1pIm3SJOEz5vvn_3DaS3lB7gHXH8BFrFcZw<mark>?theme=dark</mark></a></code></pre>
+          <div class="container">
+            <div class="columns">
+              <div class="column col-5 col-md-12">
+                <img
+                  class="img-responsive"
+                  src="/img/pako:eNpNkM9qwzAMh19F6NRB8wI5DNak7aWwwXqLexCxUpvNf3AURkny7rNbynaTPn0_ITRjHzRjjddE0cC5VR7grWtMsqM4Gi9QVa_LkQVc8HxbYLc5BhhNiNH660uxd0WBZj4ViUGM9V9rGTT37LvnBdruRFFCvPzx809YYN_ZD5MX_-cmcU4cuoHqgaqeEjSUsqBECW7RcXJkdT55LiGFYtixwjqXmgeavkWh8mtWp6hJeK-thIS1pIm3SJOEz5vvn_3DaS3lB7gHXH8BFrFcZw?theme=dark"
+                  alt="A mermaid.ink chart example"
+                />
+              </div>
+            </div>
+          </div>
+
+          <pre
+            class="code"
+            data-lang="URL"
+          ><code><a href="/img/pako:eNpNkM9qwzAMh19F6NRB8wI5DNak7aWwwXqLexCxUpvNf3AURkny7rNbynaTPn0_ITRjHzRjjddE0cC5VR7grWtMsqM4Gi9QVa_LkQVc8HxbYLc5BhhNiNH660uxd0WBZj4ViUGM9V9rGTT37LvnBdruRFFCvPzx809YYN_ZD5MX_-cmcU4cuoHqgaqeEjSUsqBECW7RcXJkdT55LiGFYtixwjqXmgeavkWh8mtWp6hJeK-thIS1pIm3SJOEz5vvn_3DaS3lB7gHXH8BFrFcZw?theme=dark&bgColor=1b1b1f">https://mermaid.ink/img/pako:eNpNkM9qwzAMh19F6NRB8wI5DNak7aWwwXqLexCxUpvNf3AURkny7rNbynaTPn0_ITRjHzRjjddE0cC5VR7grWtMsqM4Gi9QVa_LkQVc8HxbYLc5BhhNiNH660uxd0WBZj4ViUGM9V9rGTT37LvnBdruRFFCvPzx809YYN_ZD5MX_-cmcU4cuoHqgaqeEjSUsqBECW7RcXJkdT55LiGFYtixwjqXmgeavkWh8mtWp6hJeK-thIS1pIm3SJOEz5vvn_3DaS3lB7gHXH8BFrFcZw<mark>?theme=dark&bgColor=1b1b1f</mark></a></code></pre>
+          <div class="container">
+            <div class="columns">
+              <div class="column col-5 col-md-12">
+                <img
+                  class="img-responsive"
+                  src="/img/pako:eNpNkM9qwzAMh19F6NRB8wI5DNak7aWwwXqLexCxUpvNf3AURkny7rNbynaTPn0_ITRjHzRjjddE0cC5VR7grWtMsqM4Gi9QVa_LkQVc8HxbYLc5BhhNiNH660uxd0WBZj4ViUGM9V9rGTT37LvnBdruRFFCvPzx809YYN_ZD5MX_-cmcU4cuoHqgaqeEjSUsqBECW7RcXJkdT55LiGFYtixwjqXmgeavkWh8mtWp6hJeK-thIS1pIm3SJOEz5vvn_3DaS3lB7gHXH8BFrFcZw?theme=dark&bgColor=1b1b1f"
+                  alt="A mermaid.ink chart example"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="column col-12">
+          <h3>Image size</h3>
+          <p>
+            You can control the image size by using <code>width</code> and
+            <code>height</code> URL parameters. By default, without specifying
+            width or height, the size of the image will be the normal mermaid
+            image size.
+          </p>
+          <p>
+            You can scale the image by using the <code>scale</code> parameter.
+            The scale must be a number between 1 and 3. You can only set a scale
+            if one or both of width and height are set.
+          </p>
+          <p>Demo:</p>
+
+          <pre
+            class="code"
+            data-lang="URL"
+          ><code><a href="/img/pako:eNpNkM9qwzAMh19F6NRB8wI5DNak7aWwwXqLexCxUpvNf3AURkny7rNbynaTPn0_ITRjHzRjjddE0cC5VR7grWtMsqM4Gi9QVa_LkQVc8HxbYLc5BhhNiNH660uxd0WBZj4ViUGM9V9rGTT37LvnBdruRFFCvPzx809YYN_ZD5MX_-cmcU4cuoHqgaqeEjSUsqBECW7RcXJkdT55LiGFYtixwjqXmgeavkWh8mtWp6hJeK-thIS1pIm3SJOEz5vvn_3DaS3lB7gHXH8BFrFcZw?width=200">https://mermaid.ink/img/pako:eNpNkM9qwzAMh19F6NRB8wI5DNak7aWwwXqLexCxUpvNf3AURkny7rNbynaTPn0_ITRjHzRjjddE0cC5VR7grWtMsqM4Gi9QVa_LkQVc8HxbYLc5BhhNiNH660uxd0WBZj4ViUGM9V9rGTT37LvnBdruRFFCvPzx809YYN_ZD5MX_-cmcU4cuoHqgaqeEjSUsqBECW7RcXJkdT55LiGFYtixwjqXmgeavkWh8mtWp6hJeK-thIS1pIm3SJOEz5vvn_3DaS3lB7gHXH8BFrFcZw<mark>?width=200</mark></a></code></pre>
+          <div class="container">
+            <div class="columns">
+              <div class="column col-5 col-md-12">
+                <img
+                  class="img-responsive"
+                  src="/img/pako:eNpNkM9qwzAMh19F6NRB8wI5DNak7aWwwXqLexCxUpvNf3AURkny7rNbynaTPn0_ITRjHzRjjddE0cC5VR7grWtMsqM4Gi9QVa_LkQVc8HxbYLc5BhhNiNH660uxd0WBZj4ViUGM9V9rGTT37LvnBdruRFFCvPzx809YYN_ZD5MX_-cmcU4cuoHqgaqeEjSUsqBECW7RcXJkdT55LiGFYtixwjqXmgeavkWh8mtWp6hJeK-thIS1pIm3SJOEz5vvn_3DaS3lB7gHXH8BFrFcZw?width=200"
+                  alt="A mermaid.ink chart example"
+                />
+              </div>
+            </div>
+          </div>
+
+          <pre
+            class="code"
+            data-lang="URL"
+          ><code><a href="/img/pako:eNpNkM9qwzAMh19F6NRB8wI5DNak7aWwwXqLexCxUpvNf3AURkny7rNbynaTPn0_ITRjHzRjjddE0cC5VR7grWtMsqM4Gi9QVa_LkQVc8HxbYLc5BhhNiNH660uxd0WBZj4ViUGM9V9rGTT37LvnBdruRFFCvPzx809YYN_ZD5MX_-cmcU4cuoHqgaqeEjSUsqBECW7RcXJkdT55LiGFYtixwjqXmgeavkWh8mtWp6hJeK-thIS1pIm3SJOEz5vvn_3DaS3lB7gHXH8BFrFcZw?width=200&scale=2">https://mermaid.ink/img/pako:eNpNkM9qwzAMh19F6NRB8wI5DNak7aWwwXqLexCxUpvNf3AURkny7rNbynaTPn0_ITRjHzRjjddE0cC5VR7grWtMsqM4Gi9QVa_LkQVc8HxbYLc5BhhNiNH660uxd0WBZj4ViUGM9V9rGTT37LvnBdruRFFCvPzx809YYN_ZD5MX_-cmcU4cuoHqgaqeEjSUsqBECW7RcXJkdT55LiGFYtixwjqXmgeavkWh8mtWp6hJeK-thIS1pIm3SJOEz5vvn_3DaS3lB7gHXH8BFrFcZw<mark>?width=200&scale=2</mark></a></code></pre>
+          <div class="container">
+            <div class="columns">
+              <div class="column col-5 col-md-12">
+                <img
+                  class="img-responsive"
+                  src="/img/pako:eNpNkM9qwzAMh19F6NRB8wI5DNak7aWwwXqLexCxUpvNf3AURkny7rNbynaTPn0_ITRjHzRjjddE0cC5VR7grWtMsqM4Gi9QVa_LkQVc8HxbYLc5BhhNiNH660uxd0WBZj4ViUGM9V9rGTT37LvnBdruRFFCvPzx809YYN_ZD5MX_-cmcU4cuoHqgaqeEjSUsqBECW7RcXJkdT55LiGFYtixwjqXmgeavkWh8mtWp6hJeK-thIS1pIm3SJOEz5vvn_3DaS3lB7gHXH8BFrFcZw?width=200&scale=2"
+                  alt="A mermaid.ink chart example"
                 />
               </div>
             </div>

--- a/src/static/mermaid.html
+++ b/src/static/mermaid.html
@@ -7,10 +7,6 @@
       rel="stylesheet"
       href="../../node_modules/@fortawesome/fontawesome-free/css/all.min.css"
     />
-    <link
-      rel="stylesheet"
-      href="../../node_modules/@fortawesome/fontawesome-free/css/v4-shims.min.css"
-    />
   </head>
   <body>
     <div id="container"></div>

--- a/src/views/img.js
+++ b/src/views/img.js
@@ -3,9 +3,17 @@ const renderImgOrSvg = require('renderImgOrSvg');
 
 const debug = createDebug('app:views:img');
 
-const img = async (ctx, page) => {
+const img = async (ctx, page, size) => {
   const svg = await page.$('#container > svg');
   debug('got the svg element');
+
+  // If a size value has been explicitely set
+  if (size.width || size.height) {
+    await page.$eval('#container > svg', (svgElement) => {
+      // Allow the element's max-width to exceed 100% for full resolution when screenshotted
+      svgElement.style.maxWidth = null;
+    });
+  }
 
   // read type from query parameter, allow all types supported by puppeteer https://pptr.dev/api/puppeteer.screenshotoptions.type
   // defaults to jpeg, because that was originally the hardcoded type

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -3,4 +3,5 @@ module.exports = {
   servicesOembed: require('./services.oembed'),
   img: require('./img'),
   svg: require('./svg'),
+  pdf: require('./pdf'),
 };

--- a/src/views/pdf.js
+++ b/src/views/pdf.js
@@ -1,0 +1,69 @@
+const createDebug = require('debug');
+const renderImgOrSvg = require('renderImgOrSvg');
+
+const debug = createDebug('app:views:pdf');
+
+const pdf = async (ctx, page, size) => {
+  // If a size value has been explicitely set
+  if (size.width || size.height) {
+    await page.$eval('#container > svg', (svgElement) => {
+      // Allow the element's max-width to exceed 100% for full resolution when screenshotted
+      svgElement.style.maxWidth = null;
+    });
+  }
+
+  const clip = await page.$eval('#container > svg', (svgElement) => {
+    const rect = svgElement.getBoundingClientRect();
+    return {
+      x: rect.left,
+      y: rect.top,
+      width: rect.width,
+      height: rect.height,
+    };
+  });
+
+  let pdfOptions = {
+    omitBackground: true,
+    printBackground: true,
+  };
+
+  const paperFormat = [
+    'letter',
+    'legal',
+    'tabloid',
+    'ledger',
+    'a0',
+    'a1',
+    'a2',
+    'a3',
+    'a4',
+    'a5',
+    'a6',
+  ].includes(ctx.query.paper?.toLowerCase())
+    ? ctx.query.paper?.toLowerCase()
+    : 'a4';
+  const landscape = ctx.query.landscape !== undefined;
+  const pdfFit = ctx.query.fit !== undefined;
+  if (pdfFit) {
+    pdfOptions = {
+      ...pdfOptions,
+      width: Math.ceil(clip.width) + clip.x * 2 + 'px',
+      height: Math.ceil(clip.height) + clip.y * 2 + 'px',
+      pageRanges: '1-1',
+    };
+  } else {
+    pdfOptions = {
+      ...pdfOptions,
+      format: paperFormat,
+      landscape,
+    };
+  }
+
+  const pdf = await page.pdf(pdfOptions);
+  debug('printed to pdf, file size: %o', pdf.length);
+
+  ctx.type = 'application/pdf';
+  ctx.body = pdf;
+};
+
+module.exports = renderImgOrSvg(pdf);

--- a/src/views/services.oembed.js
+++ b/src/views/services.oembed.js
@@ -61,7 +61,13 @@ module.exports = async (ctx, _next) => {
     debug('loaded local mermaid page');
 
     try {
-      await renderSVG({ page, encodedCode });
+      await renderSVG({
+        page,
+        encodedCode,
+        bgColor: null,
+        size: null,
+        theme: null,
+      });
       debug('rendered SVG in DOM');
     } catch (e) {
       debug('mermaid failed to render SVG: %o', e);

--- a/src/views/svg.js
+++ b/src/views/svg.js
@@ -1,18 +1,63 @@
+const FA_VERSION =
+  require('@fortawesome/fontawesome-free/package.json').version;
 const createDebug = require('debug');
 const renderImgOrSvg = require('renderImgOrSvg');
 
 const debug = createDebug('app:views:svg');
 
-const svg = async (ctx, page) => {
-  const svg = await page.$eval('#container > svg', (e) =>
-    // this is a work-around by @hat215, for more details:
-    // https://github.com/mermaid-js/mermaid-live-editor/issues/26#issuecomment-667678228
-    e.outerHTML.replace(/<br>/gi, '<br/>')
-  );
-  debug('got the svg element, file size: %o', svg.length);
+const svg = async (ctx, page, size) => {
+  let fontAwesomeCssUrl;
+  if (ctx.state.customFontAwesomeCssUrl) {
+    fontAwesomeCssUrl = ctx.state.customFontAwesomeCssUrl.replaceAll(
+      'FA_VERSION',
+      FA_VERSION
+    );
+  } else {
+    fontAwesomeCssUrl = `https://cdnjs.cloudflare.com/ajax/libs/font-awesome/${FA_VERSION}/css/all.min.css`;
+  }
+
+  const svgString = await page.evaluate((fontAwesomeCssUrl) => {
+    function injectXmlnsXlink(svgElement) {
+      // Mermaid.js supports binding a click event to a node, it will compile a DOM
+      // element with a `xlink:href` attribute. The `xmlns:xlink` parameter is essential
+      // for the `xlink:href` parameter to not cause an error (for example: Namespace
+      // prefix xlink for href on a is not defined).
+      //
+      // For more details, see:
+      // 1. https://developer.mozilla.org/en-US/docs/Web/SVG/Namespaces_Crash_Course
+      // 2. https://mermaid.js.org/syntax/classDiagram.html#interaction
+      svgElement.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
+    }
+
+    function injectFontAwesomeCss(svgElement) {
+      const style = document.createElement('style');
+
+      style.innerText = `@import url("${fontAwesomeCssUrl}");`;
+      svgElement.prepend(style);
+    }
+
+    function fixTags(svgElement) {
+      // Ensure all HTML is valid XML in SVG - fixes <br>, <img> and other tags
+      // XMLSerializer is more effective than manual string find/replace.
+      // See https://github.com/mermaid-js/mermaid-cli/pull/378
+      const xmlSerializer = new XMLSerializer();
+      return xmlSerializer.serializeToString(svgElement);
+    }
+
+    // Clone the SVG element so that injected font does not load in browser
+    const svgElement = document
+      .querySelector('#container > svg')
+      .cloneNode(true);
+    injectXmlnsXlink(svgElement);
+    injectFontAwesomeCss(svgElement);
+    const svgString = fixTags(svgElement);
+    return svgString;
+  }, fontAwesomeCssUrl);
+
+  debug('got the svg element, file size: %o', svgString.length);
 
   ctx.type = 'image/svg+xml';
-  ctx.body = svg;
+  ctx.body = svgString;
 };
 
 module.exports = renderImgOrSvg(svg);

--- a/test/kitchensink.test.js
+++ b/test/kitchensink.test.js
@@ -1,4 +1,8 @@
 const supertest = require('supertest');
+const sharp = require('sharp');
+const { PDFDocument, PageSizes } = require('pdf-lib');
+const FA_VERSION =
+  require('@fortawesome/fontawesome-free/package.json').version;
 const createApp = require('../src/app');
 
 const KB = 1024;
@@ -103,7 +107,7 @@ describe('app', () => {
   });
 
   describe('/img', () => {
-    test('returns 400 when there is no code provided', async () => {
+    test('returns 404 when there is no code provided', async () => {
       const resp = await request.get('/img');
       expect(resp.status).toEqual(404);
     });
@@ -114,6 +118,8 @@ describe('app', () => {
       );
       expect(resp.status).toEqual(200);
       expect(resp.type).toEqual('image/jpeg');
+      const metadata = await sharp(resp.body).metadata();
+      expect(metadata.format).toEqual('jpeg');
       expect(resp.body.length).toBeGreaterThan(15 * KB);
     });
 
@@ -123,6 +129,8 @@ describe('app', () => {
       );
       expect(resp.status).toEqual(200);
       expect(resp.type).toEqual('image/jpeg');
+      const metadata = await sharp(resp.body).metadata();
+      expect(metadata.format).toEqual('jpeg');
       expect(resp.body.length).toBeGreaterThan(15 * KB);
     });
 
@@ -132,6 +140,8 @@ describe('app', () => {
       );
       expect(resp.status).toEqual(200);
       expect(resp.type).toEqual('image/jpeg');
+      const metadata = await sharp(resp.body).metadata();
+      expect(metadata.format).toEqual('jpeg');
       expect(resp.body.length).toBeGreaterThan(15 * KB);
     });
 
@@ -141,6 +151,8 @@ describe('app', () => {
       );
       expect(resp.status).toEqual(200);
       expect(resp.type).toEqual('image/png');
+      const metadata = await sharp(resp.body).metadata();
+      expect(metadata.format).toEqual('png');
       expect(resp.body.length).toBeGreaterThan(18 * KB);
     });
 
@@ -150,6 +162,8 @@ describe('app', () => {
       );
       expect(resp.status).toEqual(200);
       expect(resp.type).toEqual('image/webp');
+      const metadata = await sharp(resp.body).metadata();
+      expect(metadata.format).toEqual('webp');
       expect(resp.body.length).toBeGreaterThan(10 * KB);
     });
 
@@ -159,6 +173,8 @@ describe('app', () => {
       );
       expect(resp.status).toEqual(200);
       expect(resp.type).toEqual('image/png');
+      const metadata = await sharp(resp.body).metadata();
+      expect(metadata.format).toEqual('png');
       expect(resp.body.length).toBeGreaterThan(19 * KB);
     });
 
@@ -168,6 +184,8 @@ describe('app', () => {
       );
       expect(resp.status).toEqual(200);
       expect(resp.type).toEqual('image/jpeg');
+      const metadata = await sharp(resp.body).metadata();
+      expect(metadata.format).toEqual('jpeg');
       expect(resp.body.length).toBeGreaterThan(15 * KB);
     });
 
@@ -177,6 +195,8 @@ describe('app', () => {
       );
       expect(resp.status).toEqual(200);
       expect(resp.type).toEqual('image/jpeg');
+      const metadata = await sharp(resp.body).metadata();
+      expect(metadata.format).toEqual('jpeg');
       expect(resp.body.length).toBeGreaterThan(31 * KB);
     });
 
@@ -186,6 +206,8 @@ describe('app', () => {
       );
       expect(resp.status).toEqual(200);
       expect(resp.type).toEqual('image/jpeg');
+      const metadata = await sharp(resp.body).metadata();
+      expect(metadata.format).toEqual('jpeg');
       expect(resp.body.length).toBeGreaterThan(11 * KB);
     });
 
@@ -195,6 +217,8 @@ describe('app', () => {
       );
       expect(resp.status).toEqual(200);
       expect(resp.type).toEqual('image/jpeg');
+      const metadata = await sharp(resp.body).metadata();
+      expect(metadata.format).toEqual('jpeg');
       expect(resp.body.length).toBeGreaterThan(5 * KB);
     });
 
@@ -204,6 +228,8 @@ describe('app', () => {
       );
       expect(resp.status).toEqual(200);
       expect(resp.type).toEqual('image/jpeg');
+      const metadata = await sharp(resp.body).metadata();
+      expect(metadata.format).toEqual('jpeg');
       expect(resp.body.length).toBeGreaterThan(15 * KB);
     });
 
@@ -213,6 +239,8 @@ describe('app', () => {
       );
       expect(resp.status).toEqual(200);
       expect(resp.type).toEqual('image/jpeg');
+      const metadata = await sharp(resp.body).metadata();
+      expect(metadata.format).toEqual('jpeg');
       expect(resp.body.length).toBeGreaterThan(21 * KB);
     });
 
@@ -222,7 +250,9 @@ describe('app', () => {
       );
       expect(resp.status).toEqual(200);
       expect(resp.type).toEqual('image/jpeg');
-      expect(resp.body.length).toBeGreaterThan(34 * KB);
+      const metadata = await sharp(resp.body).metadata();
+      expect(metadata.format).toEqual('jpeg');
+      expect(resp.body.length).toBeGreaterThan(33 * KB);
     });
 
     test('returns 400 when encoded code is invalid', async () => {
@@ -236,10 +266,273 @@ describe('app', () => {
       );
       expect(resp.status).toEqual(200);
     });
+
+    test('returns 200 when theme is used', async () => {
+      const resp = await request.get(
+        '/svg/eyJjb2RlIjoiZ3JhcGggVERcbiAgQVtMb3JlbSBpcHN1bSBkb2xvciBzaXQgYW1ldCw8YnIgLz5jb25zZWN0ZXR1ciBhZGlwaXNjaW5nIGVsaXQuXSIsIm1lcm1haWQiOnsidGhlbWUiOiJkZWZhdWx0In19?theme=dark'
+      );
+      expect(resp.status).toEqual(200);
+    });
+
+    test('flowchart default size', async () => {
+      const resp = await request.get(
+        '/img/eyJjb2RlIjoiZ3JhcGggVERcbkFbQ2hyaXN0bWFzXSAtLT58R2V0IG1vbmV5fCBCKEdvIHNob3BwaW5nKVxuQiAtLT4gQ3tMZXQgbWUgdGhpbmt9XG5DIC0tPnxPbmV8IERbTGFwdG9wXVxuQyAtLT58VHdvfCBFW2lQaG9uZV1cbkMgLS0-fFRocmVlfCBGW2ZhOmZhLWNhciBDYXJdXG4iLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9fQ'
+      );
+      expect(resp.status).toEqual(200);
+      expect(resp.type).toEqual('image/jpeg');
+      const metadata = await sharp(resp.body).metadata();
+      expect(metadata.format).toEqual('jpeg');
+      expect(resp.body.length).toBeGreaterThan(15 * KB);
+
+      // Changes to the mermaid.js library, fonts and browser renderer could affect these values
+      expect(metadata.width).toEqual(303);
+      expect(metadata.height).toEqual(446);
+    });
+
+    test('flowchart set width', async () => {
+      const resp = await request.get(
+        '/img/eyJjb2RlIjoiZ3JhcGggVERcbkFbQ2hyaXN0bWFzXSAtLT58R2V0IG1vbmV5fCBCKEdvIHNob3BwaW5nKVxuQiAtLT4gQ3tMZXQgbWUgdGhpbmt9XG5DIC0tPnxPbmV8IERbTGFwdG9wXVxuQyAtLT58VHdvfCBFW2lQaG9uZV1cbkMgLS0-fFRocmVlfCBGW2ZhOmZhLWNhciBDYXJdXG4iLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9fQ?width=1000'
+      );
+      expect(resp.status).toEqual(200);
+      expect(resp.type).toEqual('image/jpeg');
+      const metadata = await sharp(resp.body).metadata();
+      expect(metadata.format).toEqual('jpeg');
+      expect(resp.body.length).toBeGreaterThan(15 * KB);
+
+      // Changes to the mermaid.js library, fonts and browser renderer could affect these values
+      expect(metadata.width).toEqual(1000);
+      expect(metadata.height).toEqual(1474);
+    });
+
+    test('flowchart set height', async () => {
+      const resp = await request.get(
+        '/img/eyJjb2RlIjoiZ3JhcGggVERcbkFbQ2hyaXN0bWFzXSAtLT58R2V0IG1vbmV5fCBCKEdvIHNob3BwaW5nKVxuQiAtLT4gQ3tMZXQgbWUgdGhpbmt9XG5DIC0tPnxPbmV8IERbTGFwdG9wXVxuQyAtLT58VHdvfCBFW2lQaG9uZV1cbkMgLS0-fFRocmVlfCBGW2ZhOmZhLWNhciBDYXJdXG4iLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9fQ?height=1000'
+      );
+      expect(resp.status).toEqual(200);
+      expect(resp.type).toEqual('image/jpeg');
+      const metadata = await sharp(resp.body).metadata();
+      expect(metadata.format).toEqual('jpeg');
+      expect(resp.body.length).toBeGreaterThan(15 * KB);
+
+      // Changes to the mermaid.js library, fonts and browser renderer could affect these values
+      expect(metadata.width).toEqual(679);
+      expect(metadata.height).toEqual(1000);
+    });
+
+    // This doesn't change the aspect ratio of the actual diagram, it just adds more margins - not very useful
+    test('flowchart set width and height', async () => {
+      const resp = await request.get(
+        '/img/eyJjb2RlIjoiZ3JhcGggVERcbkFbQ2hyaXN0bWFzXSAtLT58R2V0IG1vbmV5fCBCKEdvIHNob3BwaW5nKVxuQiAtLT4gQ3tMZXQgbWUgdGhpbmt9XG5DIC0tPnxPbmV8IERbTGFwdG9wXVxuQyAtLT58VHdvfCBFW2lQaG9uZV1cbkMgLS0-fFRocmVlfCBGW2ZhOmZhLWNhciBDYXJdXG4iLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9fQ?width=1000&height=1000'
+      );
+      expect(resp.status).toEqual(200);
+      expect(resp.type).toEqual('image/jpeg');
+      const metadata = await sharp(resp.body).metadata();
+      expect(metadata.format).toEqual('jpeg');
+      expect(resp.body.length).toBeGreaterThan(15 * KB);
+
+      expect(metadata.width).toEqual(1000);
+      expect(metadata.height).toEqual(1000);
+    });
+
+    test('flowchart set width with 2x scale', async () => {
+      const resp = await request.get(
+        '/img/eyJjb2RlIjoiZ3JhcGggVERcbkFbQ2hyaXN0bWFzXSAtLT58R2V0IG1vbmV5fCBCKEdvIHNob3BwaW5nKVxuQiAtLT4gQ3tMZXQgbWUgdGhpbmt9XG5DIC0tPnxPbmV8IERbTGFwdG9wXVxuQyAtLT58VHdvfCBFW2lQaG9uZV1cbkMgLS0-fFRocmVlfCBGW2ZhOmZhLWNhciBDYXJdXG4iLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9fQ?width=1000&scale=2'
+      );
+      expect(resp.status).toEqual(200);
+      expect(resp.type).toEqual('image/jpeg');
+      const metadata = await sharp(resp.body).metadata();
+      expect(metadata.format).toEqual('jpeg');
+      expect(resp.body.length).toBeGreaterThan(15 * KB);
+
+      // Changes to the mermaid.js library, fonts and browser renderer could affect these values
+      expect(metadata.width).toEqual(2000);
+      expect(metadata.height).toEqual(2948);
+    });
+
+    test('setting scale with no explicit width or height', async () => {
+      const resp = await request.get(
+        '/img/eyJjb2RlIjoiZ3JhcGggVERcbkFbQ2hyaXN0bWFzXSAtLT58R2V0IG1vbmV5fCBCKEdvIHNob3BwaW5nKVxuQiAtLT4gQ3tMZXQgbWUgdGhpbmt9XG5DIC0tPnxPbmV8IERbTGFwdG9wXVxuQyAtLT58VHdvfCBFW2lQaG9uZV1cbkMgLS0-fFRocmVlfCBGW2ZhOmZhLWNhciBDYXJdXG4iLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9fQ?scale=2'
+      );
+      expect(resp.status).toEqual(400);
+    });
+
+    test('scale < 0', async () => {
+      const resp = await request.get(
+        '/img/eyJjb2RlIjoiZ3JhcGggVERcbkFbQ2hyaXN0bWFzXSAtLT58R2V0IG1vbmV5fCBCKEdvIHNob3BwaW5nKVxuQiAtLT4gQ3tMZXQgbWUgdGhpbmt9XG5DIC0tPnxPbmV8IERbTGFwdG9wXVxuQyAtLT58VHdvfCBFW2lQaG9uZV1cbkMgLS0-fFRocmVlfCBGW2ZhOmZhLWNhciBDYXJdXG4iLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9fQ?width=1000&scale=-1'
+      );
+      expect(resp.status).toEqual(400);
+    });
+
+    test('scale > 3', async () => {
+      const resp = await request.get(
+        '/img/eyJjb2RlIjoiZ3JhcGggVERcbkFbQ2hyaXN0bWFzXSAtLT58R2V0IG1vbmV5fCBCKEdvIHNob3BwaW5nKVxuQiAtLT4gQ3tMZXQgbWUgdGhpbmt9XG5DIC0tPnxPbmV8IERbTGFwdG9wXVxuQyAtLT58VHdvfCBFW2lQaG9uZV1cbkMgLS0-fFRocmVlfCBGW2ZhOmZhLWNhciBDYXJdXG4iLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9fQ?width=1000&scale=4'
+      );
+      expect(resp.status).toEqual(400);
+    });
+
+    test('width < 0', async () => {
+      const resp = await request.get(
+        '/img/eyJjb2RlIjoiZ3JhcGggVERcbkFbQ2hyaXN0bWFzXSAtLT58R2V0IG1vbmV5fCBCKEdvIHNob3BwaW5nKVxuQiAtLT4gQ3tMZXQgbWUgdGhpbmt9XG5DIC0tPnxPbmV8IERbTGFwdG9wXVxuQyAtLT58VHdvfCBFW2lQaG9uZV1cbkMgLS0-fFRocmVlfCBGW2ZhOmZhLWNhciBDYXJdXG4iLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9fQ?width=-1'
+      );
+      expect(resp.status).toEqual(400);
+    });
+
+    test('width > max width ENV var', async () => {
+      const width = process.env.MAX_WIDTH + 1;
+      const resp = await request.get(
+        `/img/eyJjb2RlIjoiZ3JhcGggVERcbkFbQ2hyaXN0bWFzXSAtLT58R2V0IG1vbmV5fCBCKEdvIHNob3BwaW5nKVxuQiAtLT4gQ3tMZXQgbWUgdGhpbmt9XG5DIC0tPnxPbmV8IERbTGFwdG9wXVxuQyAtLT58VHdvfCBFW2lQaG9uZV1cbkMgLS0-fFRocmVlfCBGW2ZhOmZhLWNhciBDYXJdXG4iLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9fQ?width=${width}`
+      );
+      expect(resp.status).toEqual(400);
+    });
+
+    test('height > max height ENV var', async () => {
+      const height = process.env.MAX_HEIGHT + 1;
+      const resp = await request.get(
+        `/img/eyJjb2RlIjoiZ3JhcGggVERcbkFbQ2hyaXN0bWFzXSAtLT58R2V0IG1vbmV5fCBCKEdvIHNob3BwaW5nKVxuQiAtLT4gQ3tMZXQgbWUgdGhpbmt9XG5DIC0tPnxPbmV8IERbTGFwdG9wXVxuQyAtLT58VHdvfCBFW2lQaG9uZV1cbkMgLS0-fFRocmVlfCBGW2ZhOmZhLWNhciBDYXJdXG4iLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9fQ?height=${height}`
+      );
+      expect(resp.status).toEqual(400);
+    });
+  });
+
+  describe('/pdf', () => {
+    test('returns 404 when there is no code provided', async () => {
+      const resp = await request.get('/pdf');
+      expect(resp.status).toEqual(404);
+    });
+
+    test('flowchart', async () => {
+      const resp = await request.get(
+        '/pdf/eyJjb2RlIjoiZ3JhcGggVERcbkFbQ2hyaXN0bWFzXSAtLT58R2V0IG1vbmV5fCBCKEdvIHNob3BwaW5nKVxuQiAtLT4gQ3tMZXQgbWUgdGhpbmt9XG5DIC0tPnxPbmV8IERbTGFwdG9wXVxuQyAtLT58VHdvfCBFW2lQaG9uZV1cbkMgLS0-fFRocmVlfCBGW2ZhOmZhLWNhciBDYXJdXG4iLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9fQ'
+      );
+      expect(resp.status).toEqual(200);
+      expect(resp.type).toEqual('application/pdf');
+      expect(resp.body.length).toBeGreaterThan(19 * KB);
+
+      await PDFDocument.load(resp.body.toString('base64'));
+    });
+
+    test('should default to a4', async () => {
+      const resp = await request.get(
+        '/pdf/eyJjb2RlIjoiZ3JhcGggVERcbkFbQ2hyaXN0bWFzXSAtLT58R2V0IG1vbmV5fCBCKEdvIHNob3BwaW5nKVxuQiAtLT4gQ3tMZXQgbWUgdGhpbmt9XG5DIC0tPnxPbmV8IERbTGFwdG9wXVxuQyAtLT58VHdvfCBFW2lQaG9uZV1cbkMgLS0-fFRocmVlfCBGW2ZhOmZhLWNhciBDYXJdXG4iLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9fQ'
+      );
+      expect(resp.status).toEqual(200);
+      expect(resp.type).toEqual('application/pdf');
+      expect(resp.body.length).toBeGreaterThan(19 * KB);
+
+      const pdfDoc = await PDFDocument.load(resp.body.toString('base64'));
+      const pages = pdfDoc.getPages();
+      const firstPage = pages[0];
+      const { width, height } = firstPage.getSize();
+      const expectedSize = PageSizes.A4;
+
+      // There can be a slight difference in size
+      expect(width).toBeGreaterThan(expectedSize[0] - 1);
+      expect(width).toBeLessThan(expectedSize[0] + 1);
+      expect(height).toBeGreaterThan(expectedSize[1] - 1);
+      expect(height).toBeLessThan(expectedSize[1] + 1);
+    });
+
+    test('should set page size standard (a3)', async () => {
+      const resp = await request.get(
+        '/pdf/eyJjb2RlIjoiZ3JhcGggVERcbkFbQ2hyaXN0bWFzXSAtLT58R2V0IG1vbmV5fCBCKEdvIHNob3BwaW5nKVxuQiAtLT4gQ3tMZXQgbWUgdGhpbmt9XG5DIC0tPnxPbmV8IERbTGFwdG9wXVxuQyAtLT58VHdvfCBFW2lQaG9uZV1cbkMgLS0-fFRocmVlfCBGW2ZhOmZhLWNhciBDYXJdXG4iLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9fQ?paper=a3'
+      );
+      expect(resp.status).toEqual(200);
+      expect(resp.type).toEqual('application/pdf');
+
+      const pdfDoc = await PDFDocument.load(resp.body.toString('base64'));
+      const pages = pdfDoc.getPages();
+      const firstPage = pages[0];
+      const { width, height } = firstPage.getSize();
+      const expectedSize = PageSizes.A3;
+
+      // There can be a slight difference in size
+      expect(width).toBeGreaterThan(expectedSize[0] - 1);
+      expect(width).toBeLessThan(expectedSize[0] + 1);
+      expect(height).toBeGreaterThan(expectedSize[1] - 1);
+      expect(height).toBeLessThan(expectedSize[1] + 1);
+    });
+
+    test('should set page size standard with uppercase input (A3)', async () => {
+      const resp = await request.get(
+        '/pdf/eyJjb2RlIjoiZ3JhcGggVERcbkFbQ2hyaXN0bWFzXSAtLT58R2V0IG1vbmV5fCBCKEdvIHNob3BwaW5nKVxuQiAtLT4gQ3tMZXQgbWUgdGhpbmt9XG5DIC0tPnxPbmV8IERbTGFwdG9wXVxuQyAtLT58VHdvfCBFW2lQaG9uZV1cbkMgLS0-fFRocmVlfCBGW2ZhOmZhLWNhciBDYXJdXG4iLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9fQ?paper=A3'
+      );
+      expect(resp.status).toEqual(200);
+      expect(resp.type).toEqual('application/pdf');
+
+      const pdfDoc = await PDFDocument.load(resp.body.toString('base64'));
+      const pages = pdfDoc.getPages();
+      const firstPage = pages[0];
+      const { width, height } = firstPage.getSize();
+      const expectedSize = PageSizes.A3;
+
+      // There can be a slight difference in size
+      expect(width).toBeGreaterThan(expectedSize[0] - 1);
+      expect(width).toBeLessThan(expectedSize[0] + 1);
+      expect(height).toBeGreaterThan(expectedSize[1] - 1);
+      expect(height).toBeLessThan(expectedSize[1] + 1);
+    });
+
+    test('should silently default to a3 paper size given unexpected input', async () => {
+      const resp = await request.get(
+        '/pdf/eyJjb2RlIjoiZ3JhcGggVERcbkFbQ2hyaXN0bWFzXSAtLT58R2V0IG1vbmV5fCBCKEdvIHNob3BwaW5nKVxuQiAtLT4gQ3tMZXQgbWUgdGhpbmt9XG5DIC0tPnxPbmV8IERbTGFwdG9wXVxuQyAtLT58VHdvfCBFW2lQaG9uZV1cbkMgLS0-fFRocmVlfCBGW2ZhOmZhLWNhciBDYXJdXG4iLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9fQ?paper=not-a-size'
+      );
+      expect(resp.status).toEqual(200);
+      expect(resp.type).toEqual('application/pdf');
+
+      const pdfDoc = await PDFDocument.load(resp.body.toString('base64'));
+      const pages = pdfDoc.getPages();
+      const firstPage = pages[0];
+      const { width, height } = firstPage.getSize();
+      const expectedSize = PageSizes.A4;
+
+      // There can be a slight difference in size
+      expect(width).toBeGreaterThan(expectedSize[0] - 1);
+      expect(width).toBeLessThan(expectedSize[0] + 1);
+      expect(height).toBeGreaterThan(expectedSize[1] - 1);
+      expect(height).toBeLessThan(expectedSize[1] + 1);
+    });
+
+    test('should set landscape', async () => {
+      const resp = await request.get(
+        '/pdf/eyJjb2RlIjoiZ3JhcGggVERcbkFbQ2hyaXN0bWFzXSAtLT58R2V0IG1vbmV5fCBCKEdvIHNob3BwaW5nKVxuQiAtLT4gQ3tMZXQgbWUgdGhpbmt9XG5DIC0tPnxPbmV8IERbTGFwdG9wXVxuQyAtLT58VHdvfCBFW2lQaG9uZV1cbkMgLS0-fFRocmVlfCBGW2ZhOmZhLWNhciBDYXJdXG4iLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9fQ?landscape'
+      );
+      expect(resp.status).toEqual(200);
+      expect(resp.type).toEqual('application/pdf');
+
+      const pdfDoc = await PDFDocument.load(resp.body.toString('base64'));
+      const pages = pdfDoc.getPages();
+      const firstPage = pages[0];
+      const { width, height } = firstPage.getSize();
+      const expectedSize = PageSizes.A4;
+
+      // There can be a slight difference in size
+      expect(width).toBeGreaterThan(expectedSize[1] - 1);
+      expect(width).toBeLessThan(expectedSize[1] + 1);
+      expect(height).toBeGreaterThan(expectedSize[0] - 1);
+      expect(height).toBeLessThan(expectedSize[0] + 1);
+    });
+
+    test('should fit page size to diagram', async () => {
+      const diagramSize = [1000, 800];
+      const resp = await request.get(
+        `/pdf/eyJjb2RlIjoiZ3JhcGggVERcbkFbQ2hyaXN0bWFzXSAtLT58R2V0IG1vbmV5fCBCKEdvIHNob3BwaW5nKVxuQiAtLT4gQ3tMZXQgbWUgdGhpbmt9XG5DIC0tPnxPbmV8IERbTGFwdG9wXVxuQyAtLT58VHdvfCBFW2lQaG9uZV1cbkMgLS0-fFRocmVlfCBGW2ZhOmZhLWNhciBDYXJdXG4iLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9fQ?width=${diagramSize[0]}&height=${diagramSize[1]}&fit`
+      );
+      expect(resp.status).toEqual(200);
+      expect(resp.type).toEqual('application/pdf');
+
+      const pdfDoc = await PDFDocument.load(resp.body.toString('base64'));
+      const pages = pdfDoc.getPages();
+      expect(pages.length).toBe(1);
+      const firstPage = pages[0];
+      const { width, height } = firstPage.getSize();
+
+      // Note that the resulting PDF page size according to pdf-lib may not equal the requested diagram size but the aspect ratios will be the same
+      expect(width / height).toBeCloseTo(diagramSize[0] / diagramSize[1]);
+    });
   });
 
   describe('/svg', () => {
-    test('returns 400 when there is no code provided', async () => {
+    test('returns 404 when there is no code provided', async () => {
       const resp = await request.get('/svg');
       expect(resp.status).toEqual(404);
     });
@@ -250,6 +543,8 @@ describe('app', () => {
       );
       expect(resp.status).toEqual(200);
       expect(resp.type).toEqual('image/svg+xml');
+      const metadata = await sharp(resp.body).metadata();
+      expect(metadata.format).toEqual('svg');
       expect(resp.body.length).toBeGreaterThan(9 * KB);
     });
 
@@ -259,6 +554,8 @@ describe('app', () => {
       );
       expect(resp.status).toEqual(200);
       expect(resp.type).toEqual('image/svg+xml');
+      const metadata = await sharp(resp.body).metadata();
+      expect(metadata.format).toEqual('svg');
       expect(resp.body.length).toBeGreaterThan(9 * KB);
     });
 
@@ -268,6 +565,8 @@ describe('app', () => {
       );
       expect(resp.status).toEqual(200);
       expect(resp.type).toEqual('image/svg+xml');
+      const metadata = await sharp(resp.body).metadata();
+      expect(metadata.format).toEqual('svg');
       expect(resp.body.length).toBeGreaterThan(9 * KB);
     });
 
@@ -277,6 +576,8 @@ describe('app', () => {
       );
       expect(resp.status).toEqual(200);
       expect(resp.type).toEqual('image/svg+xml');
+      const metadata = await sharp(resp.body).metadata();
+      expect(metadata.format).toEqual('svg');
       expect(resp.body.length).toBeGreaterThan(8 * KB);
     });
 
@@ -286,6 +587,8 @@ describe('app', () => {
       );
       expect(resp.status).toEqual(200);
       expect(resp.type).toEqual('image/svg+xml');
+      const metadata = await sharp(resp.body).metadata();
+      expect(metadata.format).toEqual('svg');
       expect(resp.body.length).toBeGreaterThan(6 * KB);
     });
 
@@ -295,6 +598,8 @@ describe('app', () => {
       );
       expect(resp.status).toEqual(200);
       expect(resp.type).toEqual('image/svg+xml');
+      const metadata = await sharp(resp.body).metadata();
+      expect(metadata.format).toEqual('svg');
       expect(resp.body.length).toBeGreaterThan(6 * KB);
     });
 
@@ -304,6 +609,8 @@ describe('app', () => {
       );
       expect(resp.status).toEqual(200);
       expect(resp.type).toEqual('image/svg+xml');
+      const metadata = await sharp(resp.body).metadata();
+      expect(metadata.format).toEqual('svg');
       expect(resp.body.length).toBeGreaterThan(6 * KB);
     });
 
@@ -313,6 +620,8 @@ describe('app', () => {
       );
       expect(resp.status).toEqual(200);
       expect(resp.type).toEqual('image/svg+xml');
+      const metadata = await sharp(resp.body).metadata();
+      expect(metadata.format).toEqual('svg');
       expect(resp.body.length).toBeGreaterThan(2 * KB);
     });
 
@@ -322,7 +631,9 @@ describe('app', () => {
       );
       expect(resp.status).toEqual(200);
       expect(resp.type).toEqual('image/svg+xml');
-      expect(resp.body.length).toBeGreaterThan(13 * KB);
+      const metadata = await sharp(resp.body).metadata();
+      expect(metadata.format).toEqual('svg');
+      expect(resp.body.length).toBeGreaterThan(12 * KB);
     });
 
     test('returns 400 when encoded code is invalid', async () => {
@@ -363,12 +674,78 @@ describe('app', () => {
       expect(body).not.toMatch(/<svg [^>]* background-color:/);
     });
 
+    // Theme style contains
+    // default: #mermaid-svg .node path{fill:#ECECFF;stroke:#9370DB;stroke-width:1px;}
+    // neutral: #mermaid-svg .node path{fill:#eee;stroke:#999;stroke-width:1px;}
+    // dark: #mermaid-svg .node path{fill:#1f2020;stroke:#81B1DB;stroke-width:1px;}
+    // forest: #mermaid-svg .node path{fill:#cde498;stroke:#13540c;stroke-width:1px;}
+
+    test('site-wide diagram theme should be "default" if unset', async () => {
+      const resp = await request.get(
+        '/svg/eyJjb2RlIjoiZ3JhcGggVERcbiAgQVtMb3JlbSBpcHN1bSBkb2xvciBzaXQgYW1ldCw8YnIgLz5jb25zZWN0ZXR1ciBhZGlwaXNjaW5nIGVsaXQuXSIsIm1lcm1haWQiOnsidGhlbWUiOiJkZWZhdWx0In19'
+      );
+      expect(resp.status).toEqual(200);
+      const body = resp.body.toString();
+      expect(body).toContain(
+        '#mermaid-svg .node path{fill:#ECECFF;stroke:#9370DB;stroke-width:1px;}'
+      );
+    });
+
+    test('should set site-wide theme (dark)', async () => {
+      const resp = await request.get(
+        '/svg/eyJjb2RlIjoiZ3JhcGggVERcbiAgQVtMb3JlbSBpcHN1bSBkb2xvciBzaXQgYW1ldCw8YnIgLz5jb25zZWN0ZXR1ciBhZGlwaXNjaW5nIGVsaXQuXSIsIm1lcm1haWQiOnsidGhlbWUiOiJkZWZhdWx0In19?theme=dark'
+      );
+      expect(resp.status).toEqual(200);
+      const body = resp.body.toString();
+      expect(body).toContain(
+        '#mermaid-svg .node path{fill:#1f2020;stroke:#81B1DB;stroke-width:1px;}'
+      );
+    });
+
+    test('should silently ignore invalid site-wide themes', async () => {
+      const resp = await request.get(
+        '/svg/eyJjb2RlIjoiZ3JhcGggVERcbiAgQVtMb3JlbSBpcHN1bSBkb2xvciBzaXQgYW1ldCw8YnIgLz5jb25zZWN0ZXR1ciBhZGlwaXNjaW5nIGVsaXQuXSIsIm1lcm1haWQiOnsidGhlbWUiOiJkZWZhdWx0In19?theme=non-existant-theme'
+      );
+      expect(resp.status).toEqual(200);
+      const body = resp.body.toString();
+      expect(body).toContain(
+        '#mermaid-svg .node path{fill:#ECECFF;stroke:#9370DB;stroke-width:1px;}'
+      );
+    });
+
+    test('should add diagram-specific theme from serialized state (dark)', async () => {
+      const resp = await request.get(
+        '/svg/eyJjb2RlIjoiZ3JhcGggVERcbiAgQVtMb3JlbSBpcHN1bSBkb2xvciBzaXQgYW1ldCw8YnIgLz5jb25zZWN0ZXR1ciBhZGlwaXNjaW5nIGVsaXQuXSIsIm1lcm1haWQiOnsidGhlbWUiOiJkYXJrIn19'
+      );
+      expect(resp.status).toEqual(200);
+      const body = resp.body.toString();
+      expect(body).toContain(
+        '#mermaid-svg .node path{fill:#1f2020;stroke:#81B1DB;stroke-width:1px;}'
+      );
+    });
+
     test('imports fontawesome in svg', async () => {
       const resp = await request.get(
         '/svg/Z3JhcGggVEQKICAgIEFbQ2hyaXN0bWFzXSAtLT58R2V0IG1vbmV5fCBCKEdvIHNob3BwaW5nKQogICAgQiAtLT4gQ3tMZXQgbWUgdGhpbmt9CiAgICBDIC0tPnxPbmV8IERbTGFwdG9wXQogICAgQyAtLT58VHdvfCBFW2lQaG9uZV0KICAgIEMgLS0+fFRocmVlfCBGW2ZhOmZhLWNhciBDYXJd'
       );
       const body = resp.body.toString();
-      expect(body).toContain('font-awesome');
+      expect(body).toContain(
+        `https://cdnjs.cloudflare.com/ajax/libs/font-awesome/${FA_VERSION}/css/all.min.css`
+      );
+    });
+
+    test('imports custom fontawesome URL in svg', async () => {
+      const originalEnvValue = process.env.FONT_AWESOME_CSS_URL;
+      process.env.FONT_AWESOME_CSS_URL =
+        'https://example.com/ajax/libs/font-awesome/FA_VERSION/css/all.min.css';
+      const resp = await request.get(
+        '/svg/Z3JhcGggVEQKICAgIEFbQ2hyaXN0bWFzXSAtLT58R2V0IG1vbmV5fCBCKEdvIHNob3BwaW5nKQogICAgQiAtLT4gQ3tMZXQgbWUgdGhpbmt9CiAgICBDIC0tPnxPbmV8IERbTGFwdG9wXQogICAgQyAtLT58VHdvfCBFW2lQaG9uZV0KICAgIEMgLS0+fFRocmVlfCBGW2ZhOmZhLWNhciBDYXJd'
+      );
+      const body = resp.body.toString();
+      process.env.FONT_AWESOME_CSS_URL = originalEnvValue;
+      expect(body).toContain(
+        `https://example.com/ajax/libs/font-awesome/${FA_VERSION}/css/all.min.css`
+      );
     });
 
     test('should render svg correctly when there is clickable node in the diagram', async () => {
@@ -405,6 +782,8 @@ describe('app', () => {
       const resp = await request.get(`/img/${encodedPath}`);
       expect(resp.status).toEqual(200);
       expect(resp.type).toEqual('image/jpeg');
+      const metadata = await sharp(resp.body).metadata();
+      expect(metadata.format).toEqual('jpeg');
       expect(resp.body.length).toBeGreaterThan(15 * KB);
     });
 
@@ -412,6 +791,8 @@ describe('app', () => {
       const resp = await request.get(`/svg/${encodedPath}`);
       expect(resp.status).toEqual(200);
       expect(resp.type).toEqual('image/svg+xml');
+      const metadata = await sharp(resp.body).metadata();
+      expect(metadata.format).toEqual('svg');
       expect(resp.body.length).toBeGreaterThan(13 * KB);
     });
   });
@@ -424,6 +805,8 @@ describe('app', () => {
       const resp = await request.get(`/img/${encodedPath}`);
       expect(resp.status).toEqual(200);
       expect(resp.type).toEqual('image/jpeg');
+      const metadata = await sharp(resp.body).metadata();
+      expect(metadata.format).toEqual('jpeg');
       expect(resp.body.length).toBeGreaterThan(2 * KB);
     });
 
@@ -431,6 +814,8 @@ describe('app', () => {
       const resp = await request.get(`/svg/${encodedPath}`);
       expect(resp.status).toEqual(200);
       expect(resp.type).toEqual('image/svg+xml');
+      const metadata = await sharp(resp.body).metadata();
+      expect(metadata.format).toEqual('svg');
       expect(resp.body.length).toBeGreaterThan(4 * KB);
     });
   });


### PR DESCRIPTION
…e other things including text overflow bug.

Thanks for the project. I added some new features and fixed some things.

New additions:

- Allow setting image size with width, height and scale URL parameters. If width and height are unset, the behaviour is as before to keep backwards compatibility. (fixes #131, #85)
- Allow setting maximum allowed image width and height via ENV var
- Allow setting custom font-awesome CSS URL for SVG via ENV var
- Add support for PDF output with options for setting paper size format, fitting PDF size to image, setting landscape (fixes #303)
- Allow setting "site-wide" diagram theme using theme URL parameter (fixes #231)
- Add examples of new features to index.html page

Fixes/improvements:

- Fix google chrome executable path for Puppeteer by making absolute
- Fix typo in .dockerignore that was causing docker image build issues
- Fix corepack pnpm not being present for node user in docker image
- Add some extra error handling in getOptionsFromCode for state deserialization
- Fix to make sure "mermaid" key from deserialized state is parsed as JSON
- Remove unnecessary font-awesome v4-shims CSS from mermaid.html (all.min.css should be enough)
- Fix text overflow caused by font-awesome font loading by waiting for page fonts to load (fixes #18)
- Use the same version of CDN-hosted font-awesome CSS in SVG as vendored font-awesome by default
- When outputting SVG, clone the SVG element before injecting CDN-hosted font-awesome CSS to prevent unnecessary load on server-side
- Use XMLSerializer instead of manual tag fixing to ensure SVG is properly converted to XML when outputting SVG
- Use sharp image processor and pdf-lib packages in tests to validate format, size etc.