### PR TITLE
feat: return mermaid parse error in 400 response

### DIFF
--- a/src/node_modules/renderImgOrSvg.js
+++ b/src/node_modules/renderImgOrSvg.js
@@ -95,7 +95,7 @@ module.exports = (render) => async (ctx, encodedCode, _next) => {
       debug('rendered SVG in DOM');
     } catch (e) {
       debug('mermaid failed to render SVG: %o', e);
-      ctx.throw(400, 'invalid encoded code');
+      ctx.throw(400, e);
     }
     await render(ctx, page, size);
   } catch (e) {

--- a/src/static/mermaid.mjs
+++ b/src/static/mermaid.mjs
@@ -1,7 +1,7 @@
 import mermaid from '../../node_modules/mermaid/dist/mermaid.esm.min.mjs';
 
-function isSyntaxErrorFromMermaid(code) {
-  return code.includes('Syntax error in graph') && code.includes('error-icon');
+function isUnknownDiagramError(code) {
+  return code.includes('UnknownDiagramError');
 }
 
 function setBgColor(svgElement, bgColor) {
@@ -54,8 +54,8 @@ async function render(definition, config, bgColor, size) {
     }
   } catch (error) {
     console.error('Failed to render', error);
-    if (isSyntaxErrorFromMermaid(error.toString())) {
-      throw new Error('Syntax error in graph');
+    if (isUnknownDiagramError(error.toString())) {
+      throw new Error('Unknown diagram error');
     }
     throw error;
   }

--- a/src/static/mermaid.mjs
+++ b/src/static/mermaid.mjs
@@ -57,7 +57,7 @@ async function render(definition, config, bgColor, size) {
     if (isUnknownDiagramError(error.toString())) {
       throw new Error('Unknown diagram error');
     }
-    throw error;
+    throw error.message;
   }
 }
 


### PR DESCRIPTION
Previously sending an diagram that didn't parse always returned `invalid encoded code`

Now it returns the actual error message from the parser:
```
Parse error on line 5:
...  note for GitHubAPI::invalid syntax
-----------------------^
Expecting 'NEWLINE', 'EOF', 'SQS', 'STR', 'DOT', 'GENERICTYPE', 'LABEL', 'STRUCT_START', 'STRUCT_STOP', 'STYLE_SEPARATOR', 'ANNOTATION_END', 'AGGREGATION', 'EXTENSION', 'COMPOSITION', 'DEPENDENCY', 'LOLLIPOP', 'LINE', 'DOTTED_LINE', 'CALLBACK_NAME', 'HREF', 'ALPHA', 'NUM', 'MINUS', 'UNICODE_TEXT', 'BQUOTE_STR', got 'COLON'
Ie.parseError (file:///Users/brendan/code/mermaid.ink/node_modules/mermaid/dist/chunks/mermaid.esm.min/chunk-VVAYJJUS.mjs:1:11851)
```
