### PR TITLE
Address "No usable sandbox!" on Github Actions

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -3,7 +3,7 @@ name: CI
 on: [push]
 
 env:
-  PUPPETEER_DOWNLOAD_PATH: ${{ github.workspace }}/.cache/Puppeteer
+  PUPPETEER_SKIP_DOWNLOAD: true
 
 jobs:
   test:
@@ -20,16 +20,12 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
         run: pnpm install
+      - uses: browser-actions/setup-chrome@v1
+        id: setup-chrome
       - name: Run test
         run: pnpm test
-  check-access:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Run check
-        run: |
-          curl "https://mermaid.ink/img/eyJjb2RlIjogIiUle2luaXQ6IHsndGhlbWUnOiAnZGVmYXVsdCd9fSUlXG5mbG93Y2hhcnQgVEJcbiAgd2ViXG5cbiIsICJtZXJtYWlkIjogeyJ0aGVtZSI6ICJkZWZhdWx0In0sInVwZGF0ZUVkaXRvciI6dHJ1ZSwiYXV0b1N5bmMiOnRydWUsInVwZGF0ZURpYWdyYW0iOnRydWV9" \
-            --silent \
-            --output /dev/null
+        env:
+          PUPPETEER_EXECUTABLE_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
   build-and-push-image:
     name: Push Docker image to Github registry (ghcr.io)
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,6 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/* \
   && rm -rf /src/*.deb
 
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
-
 # node application onbuild
 RUN corepack enable
 # pnpm fetch does require only lockfile

--- a/README.md
+++ b/README.md
@@ -28,18 +28,21 @@ docker run --cap-add=SYS_ADMIN ghcr.io/jihchi/mermaid.ink
 
 Go to http://localhost:3000
 
-If you don't / can't add `--cap-add=SYS_ADMIN` to the command, please refer to [3 ways to securely use Chrome Headless with this image](https://github.com/Zenika/alpine-chrome?tab=readme-ov-file#3-ways-to-securely-use-chrome-headless-with-this-image) to find the most suitable solution for your case.
+> [!CAUTION]
+> Generally, launching a container with `--cap-add=SYS_ADMIN` is **not recommended**.
+> Please refer to [3 ways to securely use Chrome Headless with this image](https://github.com/Zenika/alpine-chrome?tab=readme-ov-file#3-ways-to-securely-use-chrome-headless-with-this-image)
+> to find the most suitable solution for your case.
 
-### With `seccomp`
+### Without `--cap-add=SYS_ADMIN`
 
-For example, you can use [Jessie Frazelle's seccomp profile for Chrome](https://github.com/Zenika/alpine-chrome/blob/master/chrome.json):
+You may use [Jessie Frazelle's seccomp profile for Chrome](https://github.com/Zenika/alpine-chrome/blob/master/chrome.json) instead:
 
 ```
 wget https://raw.githubusercontent.com/jfrazelle/dotfiles/master/etc/docker/seccomp/chrome.json
 docker run --security-opt seccomp=$(pwd)/chrome.json ghcr.io/jihchi/mermaid.ink
 ```
 
-### Environment variables
+## Environment variables
 
 | variable name          | default value | description                                                                                                                                                                                                                                                          |
 | ---------------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/src/app.js
+++ b/src/app.js
@@ -87,7 +87,8 @@ async function setup() {
       '--prerender-from-omnibox=disabled',
       // less-secure workaround to enable `import .. from '../node_modules/..'` in `src/static/mermaid.html`
       '--allow-file-access-from-files',
-    ],
+      process.env.CI ? '--no-sandbox' : undefined,
+    ].filter(Boolean),
   });
 
   app.context.browser.on('disconnected', setup);

--- a/src/app.js
+++ b/src/app.js
@@ -7,7 +7,6 @@ const puppeteer = require('puppeteer');
 const views = require('./views');
 
 const debug = createDebug('app:main');
-const pptr = createDebug('app:pptr');
 const app = new Koa();
 
 // Set global config
@@ -41,8 +40,6 @@ async function setup() {
   debug('launch headless browser instance');
 
   app.context.browser = await puppeteer.launch({
-    headless: pptr.enabled ? false : 'new',
-    devtools: pptr.enabled,
     dumpio: true,
     defaultViewport: {
       width: 1920,

--- a/src/app.js
+++ b/src/app.js
@@ -41,9 +41,6 @@ async function setup() {
   debug('launch headless browser instance');
 
   app.context.browser = await puppeteer.launch({
-    executablePath: process.env.PUPPETEER_SKIP_CHROMIUM_DOWNLOAD
-      ? '/usr/bin/google-chrome-stable'
-      : undefined,
     headless: pptr.enabled ? false : 'new',
     devtools: pptr.enabled,
     dumpio: true,


### PR DESCRIPTION
For example:

```
Run pnpm test
  pnpm test
  shell: /usr/bin/bash -e {0}
  env:
    PUPPETEER_DOWNLOAD_PATH: /home/runner/work/mermaid.ink/mermaid.ink/.cache/Puppeteer
    PNPM_HOME: /home/runner/setup-pnpm/node_modules/.bin

> mermaid.ink@11.1.0 test /home/runner/work/mermaid.ink/mermaid.ink
> jest

[1994:1994:0[2](https://github.com/jihchi/mermaid.ink/actions/runs/13490289892/job/37687346118?pr=480#step:6:2)24/033452.414952:FATAL:zygote_host_impl_linux.cc(128)] No usable sandbox! If you are running on Ubuntu 2[3](https://github.com/jihchi/mermaid.ink/actions/runs/13490289892/job/37687346118?pr=480#step:6:3).10+ or another Linux distro that has disabled unprivileged user namespaces with AppArmor, see https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md. Otherwise see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the (older) SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
[022[4](https://github.com/jihchi/mermaid.ink/actions/runs/13490289892/job/37687346118?pr=480#step:6:4)/0334[5](https://github.com/jihchi/mermaid.ink/actions/runs/13490289892/job/37687346118?pr=480#step:6:5)2.423876:ERROR:file_io_posix.cc(145)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq: No such file or directory (2)
[0224/033452.423910:ERROR:file_io_posix.cc(145)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq: No such file or directory (2)
  console.error
    *** caught exception ***

      115 |     };
      11[6](https://github.com/jihchi/mermaid.ink/actions/runs/13490289892/job/37687346118?pr=480#step:6:6) |   } catch (e) {
    > 117 |     console.error('*** caught exception ***');
          |             ^
      118 |     console.error(e);
      119 |     await shutdown();
      120 |     process.exit(1);

      at error (src/app.js:11[7](https://github.com/jihchi/mermaid.ink/actions/runs/13490289892/job/37687346118?pr=480#step:6:8):13)
      at Object.<anonymous> (test/kitchensink.test.js:32:26)

  console.error
    Error: Failed to launch the browser process!
    [1994:1994:0224/033452.414952:FATAL:zygote_host_impl_linux.cc(12[8](https://github.com/jihchi/mermaid.ink/actions/runs/13490289892/job/37687346118?pr=480#step:6:9))] No usable sandbox! If you are running on Ubuntu 23.10+ or another Linux distro that has disabled unprivileged user namespaces with AppArmor, see https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md. Otherwise see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the (older) SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
    [0224/033452.423876:ERROR:file_io_posix.cc(145)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq: No such file or directory (2)
    [0224/033452.423[9](https://github.com/jihchi/mermaid.ink/actions/runs/13490289892/job/37687346118?pr=480#step:6:10)10:ERROR:file_io_posix.cc(145)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq: No such file or directory (2)
    
    
    TROUBLESHOOTING: https://pptr.dev/troubleshooting
    
        at ChildProcess.onClose (/home/runner/work/mermaid.ink/mermaid.ink/node_modules/.pnpm/@puppeteer+browsers@2.7.0/node_modules/@puppeteer/browsers/src/launch.ts:486:[11](https://github.com/jihchi/mermaid.ink/actions/runs/13490289892/job/37687346118?pr=480#step:6:12))
        at ChildProcess.emit (node:events:529:35)
        at Process.ChildProcess._handle.onexit (node:internal/child_process:292:12)

      116 |   } catch (e) {
      117 |     console.error('*** caught exception ***');
    > 118 |     console.error(e);
          |             ^
      119 |     await shutdown();
      120 |     process.exit(1);
      121 |   }

      at error (src/app.js:118:13)
      at Object.<anonymous> (test/kitchensink.test.js:32:26)

  ●  process.exit called with "1"

      118 |     console.error(e);
      119 |     await shutdown();
    > [12](https://github.com/jihchi/mermaid.ink/actions/runs/13490289892/job/37687346118?pr=480#step:6:13)0 |     process.exit(1);
          |             ^
      121 |   }
      122 | };
      123 |

      at exit (src/app.js:120:13)
      at Object.<anonymous> (test/kitchensink.test.js:32:26)
 ELIFECYCLE  Test failed. See above for more details.
Error: Process completed with exit code 1.
```
