### PR TITLE
Add support for customizing `protocolTimeout`

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -40,6 +40,7 @@ async function setup() {
   debug('launch headless browser instance');
 
   app.context.browser = await puppeteer.launch({
+    protocolTimeout: process.env.PROTOCOL_TIMEOUT,
     dumpio: true,
     defaultViewport: {
       width: 1920,

--- a/src/node_modules/renderImgOrSvg.js
+++ b/src/node_modules/renderImgOrSvg.js
@@ -84,10 +84,13 @@ module.exports = (render) => async (ctx, encodedCode, _next) => {
   let page;
   try {
     page = await openMermaidPage(ctx);
-    const bgColor = bgColorFromContext(ctx);
-    const size = sizeFromContext(ctx);
-    const theme = themeFromContext(ctx);
     debug('loaded local mermaid page');
+    const bgColor = bgColorFromContext(ctx);
+    debug('set background color to %s', bgColor);
+    const size = sizeFromContext(ctx);
+    debug('set size to %s', size);
+    const theme = themeFromContext(ctx);
+    debug('set theme to %s', theme);
 
     try {
       await renderSVG({ page, encodedCode, bgColor, size, theme });
@@ -96,16 +99,20 @@ module.exports = (render) => async (ctx, encodedCode, _next) => {
       debug('mermaid failed to render SVG: %o', e);
       ctx.throw(400, e);
     }
+
     await render(ctx, page, size);
+    debug('body is ready to respond');
   } catch (e) {
+    debug('*** caught exception ***');
+    debug(e);
+
     // here don't throw 500 if exception has already been thrown inside try-catch
     if (!ctx.headerSent) {
-      debug('*** caught exception ***');
-      debug(e);
-
       ctx.throw(500, e);
     }
   } finally {
-    if (page) await page.close();
+    if (page) {
+      await page.close();
+    }
   }
 };


### PR DESCRIPTION
As well as adding more logs in order to investigate `ProtocolError: Runtime.callFunctionOn timed out.` error. For example:

```
ProtocolError: Runtime.callFunctionOn timed out. Increase the 'protocolTimeout' setting in launch/connect calls for a higher timeout if needed.
    at <instance_members_initializer> (/home/pptruser/node_modules/.pnpm/puppeteer-core@24.8.2/node_modules/puppeteer-core/lib/cjs/puppeteer/common/CallbackRegistry.js:101:14)
    at new Callback (/home/pptruser/node_modules/.pnpm/puppeteer-core@24.8.2/node_modules/puppeteer-core/lib/cjs/puppeteer/common/CallbackRegistry.js:105:16)
    at CallbackRegistry.create (/home/pptruser/node_modules/.pnpm/puppeteer-core@24.8.2/node_modules/puppeteer-core/lib/cjs/puppeteer/common/CallbackRegistry.js:23:26)
    at Connection._rawSend (/home/pptruser/node_modules/.pnpm/puppeteer-core@24.8.2/node_modules/puppeteer-core/lib/cjs/puppeteer/cdp/Connection.js:99:26)
    at CdpCDPSession.send (/home/pptruser/node_modules/.pnpm/puppeteer-core@24.8.2/node_modules/puppeteer-core/lib/cjs/puppeteer/cdp/CdpSession.js:73:33)
    at #evaluate (/home/pptruser/node_modules/.pnpm/puppeteer-core@24.8.2/node_modules/puppeteer-core/lib/cjs/puppeteer/cdp/ExecutionContext.js:363:50)
    at ExecutionContext.evaluate (/home/pptruser/node_modules/.pnpm/puppeteer-core@24.8.2/node_modules/puppeteer-core/lib/cjs/puppeteer/cdp/ExecutionContext.js:277:36)
    at IsolatedWorld.evaluate (/home/pptruser/node_modules/.pnpm/puppeteer-core@24.8.2/node_modules/puppeteer-core/lib/cjs/puppeteer/cdp/IsolatedWorld.js:100:30)
    at CdpJSHandle.evaluate (/home/pptruser/node_modules/.pnpm/puppeteer-core@24.8.2/node_modules/puppeteer-core/lib/cjs/puppeteer/api/JSHandle.js:149:37)
    at CdpElementHandle.evaluate (/home/pptruser/node_modules/.pnpm/puppeteer-core@24.8.2/node_modules/puppeteer-core/lib/cjs/puppeteer/api/ElementHandle.js:344:38)
```