### PR TITLE
Switch to `chrome-headless-shell` (aka the old headless mode)

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -41,6 +41,7 @@ async function setup() {
 
   app.context.browser = await puppeteer.launch({
     protocolTimeout: process.env.PROTOCOL_TIMEOUT,
+    headless: 'shell',
     dumpio: true,
     defaultViewport: {
       width: 1920,


### PR DESCRIPTION
An attempt to address #537. Inspired by https://github.com/puppeteer/puppeteer/issues/12712#issuecomment-2217237932.